### PR TITLE
Update VectorDB creation job, RAG LLM service for Chat-in-a-box with RAG

### DIFF
--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: serveragllm-deployment
+  labels:
+    app: modelragllmserve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      model: serveragllm
+  template:
+    metadata:
+      labels:
+        model: serveragllm
+    spec:
+      containers:
+        - name: serveragllm
+          image: elotl/serveragllm:v1.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              cpu: "1.5"
+              memory: "1G"
+          env:
+          - name: MODEL_LLM_SERVER_URL
+            value: ${MODEL_LLM_SERVER_URL}
+          - name: AWS_ACCESS_KEY_ID
+            value: ${AWS_ACCESS_KEY_ID}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${AWS_SECRET_ACCESS_KEY}
+          - name: VECTOR_DB_S3_BUCKET
+            value: ${VECTOR_DB_S3_BUCKET}
+          - name: VECTOR_DB_S3_FILE
+            value: ${VECTOR_DB_S3_FILE}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: serveragllm-service
+  labels:
+    app: modelragllmserve
+spec:
+  type: LoadBalancer
+  selector:
+    model: serveragllm
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createvectordb
+  labels:
+    app: modeldataingest
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: createvectordb
+        image: elotl/createvectordb:v1.1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "1.5"
+            memory: "1G"
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            value: ${AWS_ACCESS_KEY_ID}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${AWS_SECRET_ACCESS_KEY}
+          - name: VECTOR_DB_INPUT_TYPE
+            value: ${VECTOR_DB_INPUT_TYPE}
+          - name: VECTOR_DB_INPUT_ARG
+            value: ${VECTOR_DB_INPUT_ARG}
+          - name: VECTOR_DB_S3_BUCKET
+            value: ${VECTOR_DB_S3_BUCKET}
+          - name: VECTOR_DB_S3_FILE
+            value: ${VECTOR_DB_S3_FILE}

--- a/dockers/llm.rag.service/Dockerfile
+++ b/dockers/llm.rag.service/Dockerfile
@@ -23,7 +23,7 @@ COPY pyproject.toml .
 
 RUN --mount=type=cache,target=/root/.cache/pip \
   pip3 install -v --no-cache-dir \
-  "openai" "langchain" "sentence-transformers" "faiss-cpu" "uvicorn[standard]" "fastapi" "boto3" && \
+  "openai" "langchain" "langchain_community" "langchain_huggingface" "unstructured" "sentence-transformers" "faiss-cpu" "uvicorn[standard]" "fastapi" "boto3" && \
   pip3 install --no-cache-dir -e .
 
 EXPOSE 8000

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -1,19 +1,20 @@
-from typing import Union
-from fastapi import FastAPI
-
 import os
 import sys
-import openai
-from langchain_community.embeddings import HuggingFaceEmbeddings
-from langchain_community.vectorstores import FAISS
-
 import boto3
 import pickle
 import time
 
+from typing import Union
+from fastapi import FastAPI
+from botocore.exceptions import NoCredentialsError, ClientError
+
+from openai import OpenAI
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
+
 ########
 # Setup model name and query template parameters
-model = "mosaicml--mpt-7b-chat"
+model = "mosaicml/mpt-7b-chat"
 template = """Answer the question based only on the following context:
 {context}
 
@@ -22,44 +23,97 @@ Question: {question}
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 ########
+# Fetch RAG context for question, form prompt from context and question, and call model
+def get_answer(question: Union[str, None]):
+
+    print("Received question: ", question)
+    # retrieve docs relevant to the input question
+    docs = retriever.invoke(input=question)
+    # default number of docs is 4; make this configurable later
+    print ("Number of relevant documents retrieved and that will be used as context for query: ", len(docs))
+
+    # concatenate relevant docs retrieved to be used as context 
+    allcontext = ""
+    for i in range(len(docs)):
+        allcontext += docs[i].page_content
+    promptstr = template.format(context=allcontext, question=question)
+    
+    print("Sending query to the LLM...")
+    completions = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {
+                "role": "user",
+                "content": promptstr,
+            },
+        ],
+        max_tokens=64,
+        temperature=0.01,
+        stream=False,
+    )
+   
+    answer = completions.choices[0].message.content
+    print("Received answer: ", answer)
+    return answer
+
+
+########
 # Get connection to LLM server
 model_llm_server_url = os.environ.get('MODEL_LLM_SERVER_URL')
 if model_llm_server_url is None:
-    print("Please set environment variable MODEL_LLM_SERVER_URL")
-    sys.exit(1)
+    model_llm_server_url = "http://llm-model-serve-serve-svc.default.svc.cluster.local:8000"
+    print("Setting environment variable MODEL_LLM_SERVER_URL to default value: ", model_llm_server_url )
 llm_server_url = model_llm_server_url + '/v1'
-client = openai.OpenAI(base_url=llm_server_url, api_key='na')
+
+print("Creating an OpenAI client to the hosted model at URL: ", llm_server_url)
+try:
+    client = OpenAI(base_url=llm_server_url, api_key='na')
+except Exception as e:
+    print("Error creating client:", e)
+    sys.exit(1)
 
 ########
 # Load vectorstore and get retriever for it
-vectordb_bucket = "faiss-vectordbs"
+
+# get env vars needed to access Vector DB
+vectordb_bucket = os.environ.get('VECTOR_DB_S3_BUCKET')
+print ("Using vector DB s3 bucket: ", vectordb_bucket)
+if vectordb_bucket is None:
+    print("Please set environment variable VECTOR_DB_S3_BUCKET")
+    sys.exit(1)
+
 vectordb_key = os.environ.get('VECTOR_DB_S3_FILE')
+print ("Using vector DB s3 file containing vector store: ", vectordb_key)
 if vectordb_key is None:
     print("Please set environment variable VECTOR_DB_S3_FILE")
     sys.exit(1)
+
+# Use s3 client to read in vector store
 s3_client = boto3.client('s3')
-response = s3_client.get_object(Bucket=vectordb_bucket, Key=vectordb_key)
-print(response)
+response = None
+try:
+    response = s3_client.get_object(Bucket=vectordb_bucket, Key=vectordb_key)
+except ClientError as e:
+    print(f"Error accessing object, {vectordb_key} in bucket, {vectordb_bucket}, err: {e}")
+    sys.exit(1)
 body = response['Body'].read()
+
+print("Loading Vector DB...\n")
+# needs prereq packages: sentence_transformers and faiss-cpu
 vectorstore = pickle.loads(body)
 retriever = vectorstore.as_retriever()
-time.sleep(30)
+print("Created Vector DB retriever successfully. \n")
+
+# Uncomment to run a local test
+# print("Testing with a sample question:")
+# get_answer("who are you?")
 
 ########
-# Fetch RAG context for question, form prompt from context and question, and call model
-def get_answer(question: Union[str, None]):
-    docs = retriever.get_relevant_documents(question)
-    promptstr = template.format(context=docs[0].page_content, question=question)
-    completions = client.completions.create(prompt=promptstr, model=model, max_tokens=64, temperature=0.1)
-    print("Question: ", question)
-    print("Completions: ", completions)
-    answer = completions.choices[0].text + "\n"
-    return answer
-
-########
-# Start API service to answer question
+# Start API service to answer questions
 app = FastAPI()
 @app.get("/answer/{question}")
 def read_item(question: Union[str, None] = None):
+    print(f"Received question: {question}")
     answer = get_answer(question)
     return {"question": question, "answer": answer}

--- a/dockers/llm.vdb.service/Dockerfile
+++ b/dockers/llm.vdb.service/Dockerfile
@@ -12,9 +12,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   ca-certificates \
   ccache \
   curl \
+  libmagic1 \
+  file \
   libssl-dev ca-certificates make \
   git python3-pip && \
   rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies (including python-magic)
+RUN pip install python-magic
 
 WORKDIR /createvectordb
 
@@ -23,7 +28,7 @@ COPY pyproject.toml .
 
 RUN --mount=type=cache,target=/root/.cache/pip \
   pip3 install -v --no-cache-dir \
-  "langchain" "sentence-transformers" "faiss-cpu" "boto3" "lxml" "bs4" && \
+  "langchain" "langchain_community" "langchain_huggingface" "unstructured" "sentence-transformers" "faiss-cpu" "boto3" "lxml" "bs4" "python-magic" && \
   pip3 install --no-cache-dir -e .
 
 CMD ["python", "createvectordb.py"]

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -1,55 +1,156 @@
 import os
 import sys
 
-from langchain_community.embeddings import HuggingFaceEmbeddings
-from langchain_community.vectorstores import FAISS
-from langchain_community.document_loaders.sitemap import SitemapLoader
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-
 import boto3
 import pickle
+from botocore.exceptions import NoCredentialsError, ClientError
 
-vectordb_bucket = "faiss-vectordbs"
+from langchain_community.vectorstores import FAISS
+from langchain_community.document_loaders.sitemap import SitemapLoader
+from langchain_community.document_loaders import DirectoryLoader
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.text_splitter import CharacterTextSplitter
 
-vectordb_key = os.environ.get('VECTOR_DB_S3_FILE')
-if vectordb_key is None:
-    print("Please set environment variable VECTOR_DB_S3_FILE")
-    sys.exit(1)
+def list_files_in_s3_folder(bucket_name, folder_name, s3_client):
+    """
+    List all files within a given folder (prefix) in an S3 bucket. Any folders within are ignored.
+    """
+    try:
+        # List all objects in the specified folder
+        response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=folder_name)
+        
+        if 'Contents' not in response:
+            print(f"No files found in folder {folder_name} in bucket {bucket_name}")
+            return []
+        
+        file_names = []
+        for content in response['Contents']: 
+            # ignoring any folders within the top-level folder
+            if not content['Key'].endswith('/'):
+                file_names.append(content['Key']) 
+        return file_names
+    
+    except ClientError as e:
+        print(f"Error listing files in the S3 bucket, {bucket_name}, folder, {folder_name}, err: {e}")
+        return []
 
-vectordb_input_type = os.environ.get('VECTOR_DB_INPUT_TYPE')
-if vectordb_input_type is None:
-    print("Please set environment variable VECTOR_DB_INPUT_TYPE")
-    sys.exit(1)
+def download_files_from_s3(bucket_name, folder_name, local_dir):
+    """
+    Download all files from a folder in an S3 bucket to a local directory.
+    """
 
-vectordb_input_arg = os.environ.get('VECTOR_DB_INPUT_ARG')
-if vectordb_input_arg is None:
-    print("Please set environment variable VECTOR_DB_INPUT_ARG")
-    sys.exit(1)
+    # Initialize the S3 client
+    s3_client = boto3.client('s3')
 
-# Initialize vectorstore and create pickle representation
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
-if vectordb_input_type == 'text':
-    vectorstore = FAISS.from_texts(vectordb_input_arg, embedding=HuggingFaceEmbeddings())
-elif vectordb_input_type == 'sitemap':
-    sitemap_loader = SitemapLoader(web_path=vectordb_input_arg, filter_urls=["^((?!.*/v.*).)*$"])
-    sitemap_loader.requests_per_second = 1
-    docs = sitemap_loader.load()
-    print("Count of sitemap docs loaded:", len(docs))
-    text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size = 1000,
-        chunk_overlap  = 100,
-        length_function = len,
-    )
-    texts = text_splitter.split_documents(docs)
-    vectorstore = FAISS.from_documents(texts, embedding=HuggingFaceEmbeddings())
-else:
-    print("Unknown value for VECTOR_DB_INPUT_TYPE:", vectordb_input_type)
-    sys.exit(1)
+    # List and download files from the specified S3 folder
+    file_names = list_files_in_s3_folder(bucket_name, folder_name, s3_client)
+    print(f"Number of files in S3 folder: {len(file_names)}")
+    if file_names:
+        print(f"Found {len(file_names)} file(s) in the folder '{folder_name}'")
+        for file_name in file_names:
+            local_file_path = os.path.join(local_dir, os.path.basename(file_name))
+            
+            try:
+                # download file
+                s3_client.download_file(bucket_name, file_name, local_file_path)
+                print(f"Downloaded file, {file_name} successfully to directory, {local_dir}")
+            except Exception as e:
+                print(f"Error while downloading file, {file_name} from S3, {bucket_name}, err: {e}")
+    else:
+        print(f"No files to download in folder {folder_name} in bucket, {bucket_name}.")
+        return 0    
+    return len(file_names)
 
-pickle_byte_obj = pickle.dumps(vectorstore)
 
-# Persist vectorstore to S3 bucket vectorstores
-s3_client = boto3.client('s3')
-s3_client.put_object(Body=pickle_byte_obj, Bucket=vectordb_bucket, Key=vectordb_key)
-print("Uploaded vectordb to", vectordb_bucket, vectordb_key)
-sys.exit(0)
+if __name__ == "__main__":
+
+    vectordb_input_type = os.environ.get('VECTOR_DB_INPUT_TYPE')
+    if vectordb_input_type is None:
+        print("Please set environment variable VECTOR_DB_INPUT_TYPE")
+        sys.exit(1)
+
+    vectordb_input_arg = os.environ.get('VECTOR_DB_INPUT_ARG')
+    if vectordb_input_arg is None:
+        print("Please set environment variable VECTOR_DB_INPUT_ARG")
+        sys.exit(1)
+
+    # This is the bucket that will be used to store both input datasets for 
+    # RAG as well as the Vector DB created from this dataset
+    vectordb_bucket = os.environ.get('VECTOR_DB_S3_BUCKET')
+    if vectordb_bucket is None:
+        print("Please set environment variable VECTOR_DB_S3_BUCKET")
+        sys.exit(1)
+
+    # This is the name of the Vector DB file that will be created by this script
+    # and will be used by query_rag.py. It has to be unique for each dataset
+    # corresponding to a unique VectorDB (or vector store)
+    vectordb_file = os.environ.get('VECTOR_DB_S3_FILE')
+    if vectordb_file is None:
+        print("Please set environment variable VECTOR_DB_S3_FILE")
+        sys.exit(1)
+
+    # Initialize vectorstore and create pickle representation
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    if vectordb_input_type == 'text':
+        vectorstore = FAISS.from_texts(vectordb_input_arg, embedding=HuggingFaceEmbeddings())
+    elif vectordb_input_type == 'sitemap':
+        sitemap_loader = SitemapLoader(web_path=vectordb_input_arg, filter_urls=["^((?!.*/v.*).)*$"])
+        sitemap_loader.requests_per_second = 1
+        docs = sitemap_loader.load()
+        print("Count of sitemap docs loaded:", len(docs))
+
+        text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size = 1000,
+            chunk_overlap  = 100,
+            length_function = len,
+        )
+        texts = text_splitter.split_documents(docs)
+
+        vectorstore = FAISS.from_documents(texts, embedding=HuggingFaceEmbeddings())
+    elif vectordb_input_type == 'text-docs':
+        #Ref: https://python.langchain.com/docs/integrations/vectorstores/faiss
+
+        # download text documents from the S3 bucket 
+
+        # This is a folder within the S3 bucket which will contain all the 
+        # text documents that need to be used as the RAG dataset 
+        vectordb_s3_input_dir = vectordb_input_arg
+        
+        # this is a temporary folder where all the text documents from S3 are stored locally
+        # before saving it in the Vector DB
+        # TODO (improvement for later) update to using text data from the S3 bucket directly
+        local_tmp_dir = "/tmp/" + vectordb_file
+
+        # create this temp dir if it does not already exist
+        if not os.path.exists(local_tmp_dir):
+            os.makedirs(local_tmp_dir)
+
+        # download text docs from S3 bucket + folder (vectordb_s3_input_dir/arg) into this tmp local directory
+        num_files = download_files_from_s3(vectordb_bucket, vectordb_input_arg, local_tmp_dir)
+        print(f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}")
+
+        loader = DirectoryLoader(local_tmp_dir, glob="**/*")    
+        documents = loader.load()
+        print(f"Number of documents loaded via DirectoryLoader is {len(documents)}") 
+
+        # TODO (improvement for later) Allow users to configure chunk size and overlap values
+        text_splitter = CharacterTextSplitter(chunk_size=2000, chunk_overlap=100)
+        docs = text_splitter.split_documents(documents)
+        
+        # default model name values has been deprecated since 0.2.16, so we choose a specific model
+        embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+        vectorstore = FAISS.from_documents(docs, embeddings)
+    else:
+        print("Unknown value for VECTOR_DB_INPUT_TYPE:", vectordb_input_type)
+        sys.exit(1)
+
+    pickle_byte_obj = pickle.dumps(vectorstore)
+
+    # Persist vectorstore to S3 bucket vectorstores
+    s3_client = boto3.client('s3')
+    s3_client.put_object(Body=pickle_byte_obj, Bucket=vectordb_bucket, Key=vectordb_file)
+    print("Uploaded vectordb to", vectordb_bucket, vectordb_file)
+    sys.exit(0)


### PR DESCRIPTION

* Enable creation of a vector DB with text docs downloaded from an S3 bucket. Added a new INPUT_TYPE value "text-docs" to the vector DB creation docker container for this. These text documents will be used as the RAG dataset.
* Created new versions of the VectorDB creation job and RAG LLM service that have two changes
   - Do not need the image pull secret i.e (registry credentials, "regcred"). Corresponding images have been made public.
   - Both these k8s resources run in the default namespace (rather that MODEL_NAMESPACE)
* Moved from using OpenAI API client.completions.create to client.chat.completions.create This needed newer langchain packages to be added to the Dockerfile. This has meant that the answer is now available in completions.choices[0].message.content (which was previously available in completions.choices[0].text)
* Increased RAG context from 1 doc to 4 docs

Minor:
- Added error handling for OpenAI client creation and S3 client's object access
- Removed 30s sleep after Vector RB retriever is created, since it didn't seem necessary
- Added Env Var VECTOR_DB_S3_BUCKET to specify an S3 bucket instead of prior hard-coded value
- If Env Var MODEL_LLM_SERVER_URL is not defined, we will use a preset default.
- Changed model name from "mosaicml--mpt-7b-chat" to "mosaicml/mpt-7b-chat" since the former was producing an error.