### PR TITLE
Make Model, Vector store embedding and Vector store Retrieving parameters configurable

### DIFF
--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -13,10 +13,12 @@ spec:
     metadata:
       labels:
         model: serveragllm
+      annotations:
+        node.elotl.co/instance-type-regexp: "^t3.xlarge$"
     spec:
       containers:
         - name: serveragllm
-          image: elotl/serveragllm:v1.1
+          image: elotl/serveragllm:v1.2
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -35,6 +37,14 @@ spec:
             value: ${VECTOR_DB_S3_BUCKET}
           - name: VECTOR_DB_S3_FILE
             value: ${VECTOR_DB_S3_FILE}
+          - name: MODEL_ID
+            value: ${MODEL_ID}
+          - name: MAX_TOKENS
+            value: ${MAX_TOKENS}
+          - name: MODEL_TEMPERATURE
+            value: ${MODEL_TEMPERATURE}
+          - name: RELEVANT_DOCS
+            value: ${RELEVANT_DOCS}
 ---
 apiVersion: v1
 kind: Service

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -4,6 +4,8 @@ metadata:
   name: createvectordb
   labels:
     app: modeldataingest
+  annotations:
+    node.elotl.co/instance-type-regexp: "^t3.xlarge$"
 spec:
   ttlSecondsAfterFinished: 120
   template:
@@ -11,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: createvectordb
-        image: elotl/createvectordb:v1.1
+        image: elotl/createvectordb:v1.2
         imagePullPolicy: Always
         resources:
           requests:
@@ -30,3 +32,9 @@ spec:
             value: ${VECTOR_DB_S3_BUCKET}
           - name: VECTOR_DB_S3_FILE
             value: ${VECTOR_DB_S3_FILE}
+          - name: EMBEDDING_CHUNK_SIZE
+            value: ${EMBEDDING_CHUNK_SIZE}
+          - name: EMBEDDING_CHUNK_OVERLAP
+            value: ${EMBEDDING_CHUNK_OVERLAP}
+          - name: EMBEDDING_MODEL_NAME
+            value: ${EMBEDDING_MODEL_NAME}

--- a/dockers/llm.rag.service/makeDocker.sh
+++ b/dockers/llm.rag.service/makeDocker.sh
@@ -8,5 +8,5 @@ SERVE_RAG_LLM_TAG=$2
 
 echo ""
 echo "Building docker for rag+llm service"
-docker build --platform=linux/amd64 --load -f ./Dockerfile -t ${SERVE_RAG_LLM_REPO}:${SERVE_RAG_LLM_TAG} .
+docker buildx build --platform=linux/amd64 --load -f ./Dockerfile -t ${SERVE_RAG_LLM_REPO}:${SERVE_RAG_LLM_TAG} .
 docker push ${SERVE_RAG_LLM_REPO}:${SERVE_RAG_LLM_TAG}

--- a/dockers/llm.vdb.service/makeDocker.sh
+++ b/dockers/llm.vdb.service/makeDocker.sh
@@ -8,5 +8,5 @@ CREATE_VECTOR_DB_TAG=$2
 
 echo ""
 echo "Building docker for vectordb creation"
-docker build --platform=linux/amd64 --load -f ./Dockerfile -t ${CREATE_VECTOR_DB_REPO}:${CREATE_VECTOR_DB_TAG} .
+docker buildx build --platform=linux/amd64 --load -f ./Dockerfile -t ${CREATE_VECTOR_DB_REPO}:${CREATE_VECTOR_DB_TAG} .
 docker push ${CREATE_VECTOR_DB_REPO}:${CREATE_VECTOR_DB_TAG}


### PR DESCRIPTION
## What does this PR do? 

This PR makes a number of model, embedding and retrieval parameters configurable via environment variables to the respective Docker containers.
    
    - Added these configurable values to the RAG LLM service:
        MODEL_ID (DEFAULT=mosaicml/mpt-7b-chat)
        RELEVANT_DOCS (DEFAULT = 2)
        MAX_TOKENS (DEFAULT=128)
        MODEL_TEMPERATURE (DEFAULT=0.01)
    - Added these configurable values to the Vector DB creation job:
        EMBEDDING_CHUNK_SIZE (DEFAULT=1000)
        EMBEDDING_CHUNK_OVERLAP (DEFAULT=100)
        EMBEDDING_MODEL_NAME (DEFAULT=sentence-transformers/all-MiniLM-L6-v2)
    - Handle integer and float embedding and RAG querying configuration parameters correctly
    - Use explicit embedding model for RAG dataset type sitemap
    - Adding logs for all the newly added configurable parameters
    Related fixes:
    - Explicit convertion of non-string parameters to int and float (and only if its non-empty)
    - Remove setting k (number of relevant docs) for retriever.invoke (only applicable for as_retriever)
    
In addition, this PR includes:
    - Updating both vectorDB creation K8s Job and RAG LLM K8s deployment to use Intel instance types via Luna annotations
    
 ## Testing
 
This was manually tested with two questions. One question that could not be answered by the Mini RAG dataset and another question that could be answered. This is the snippet of the logs from the RAG LLM service with the output of both:

***************************************************
Question 1
***************************************************

Creating an OpenAI client to the hosted model at URL:  http://llm-model-serve-serve-svc.default.svc.cluster.local:8000/v1
Using vector DB s3 bucket:  selvi-faiss-vectordbs
Using Vector DB S3 bucket:  selvi-faiss-vectordbs
Using vector DB s3 file containing vector store:  selvi-s3-rag-wikipedia
Using Vector DB S3 file:  selvi-s3-rag-wikipedia
Using top-k search from Vector DB, k:  2
Loading Vector DB...
Created Vector DB retriever successfully. 
Received question: what was the description of the most recent security ticket in Luna
Using Model ID:  mosaicml/mpt-7b-chat
Using Model Temperature:  0.01
Using Max Tokens:  128
Using top-k search from Vector DB, k:  2
Number of relevant documents retrieved and that will be used as context for query:  2
Sending query to the LLM...
Received answer:  I'm sorry, I don't have access to that information.
INFO:     192.168.136.123:62303 - "GET /answer/what%20was%20the%20description%20of%20the%20most%20recent%20security%20ticket%20in%20Luna HTTP/1.1" 200 OK

***************************************************
Question 2
***************************************************
Received question:  what are the two types of African elephants 
Using Model ID:  mosaicml/mpt-7b-chat
Using Model Temperature:  0.01
Using Max Tokens:  128
Using top-k search from Vector DB, k:  2
Number of relevant documents retrieved and that will be used as context for query:  2
Sending query to the LLM...
Received answer:  The two types of African elephants are the savanna elephant (Loxodonta africana africana) and the forest elephant (Loxodonta cyclotis).
INFO:     192.168.130.50:56544 - "GET /answer/what%20are%20the%20two%20types%20of%20African%20elephants%20 HTTP/1.1" 200 OK
