### PR TITLE
Add a simple chat UI

### DIFF
--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -1,0 +1,50 @@
+import os
+import requests
+import sys
+import urllib
+
+import gradio as gr
+
+RAG_LLM_QUERY_URL = os.getenv("RAG_LLM_QUERY_URL")
+if  RAG_LLM_QUERY_URL is None:
+    print("Please set environment variable, RAG_LLM_QUERY_URL (to the IP of the RAG + LLM endpoint)")
+    sys.exit(1)
+print("RAG query endpoint, RAG_LLM_QUERY_URL: ", RAG_LLM_QUERY_URL)
+
+USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", False)
+
+def get_api_response(user_message):
+    try:
+        question = urllib.parse.quote(f"{user_message}")
+        response = requests.get(f"{RAG_LLM_QUERY_URL}/answer/{question}")
+        if response.status_code == 200:
+            return response.json().get("answer", "Could not fetch response.")
+        else:
+            return "API Error: Unable to fetch response."
+    except requests.RequestException:
+        return "API Error: Failed to connect to the backend service."
+
+def chatbot_response_no_hist(_chatbot, user_message):
+    random_text = get_api_response(user_message)
+    return [[user_message, random_text]], ""
+
+def chatbot_response(history, user_message):
+    random_text = get_api_response(user_message)
+    history.append((user_message, random_text))
+    return history, ""
+
+with gr.Blocks() as app:
+    with gr.Row():
+        with gr.Column(scale=4):
+            chatbot = gr.Chatbot()
+            msg = gr.Textbox(placeholder="Type here...", label="Message")
+            send_button = gr.Button("Send")
+
+    if USE_CHATBOT_HISTORY:
+        msg.submit(chatbot_response, inputs=[chatbot, msg], outputs=[chatbot, msg])
+        send_button.click(chatbot_response, inputs=[chatbot, msg], outputs=[chatbot, msg])
+    else:
+        msg.submit(chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg])
+        send_button.click(chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg])
+
+app.launch()


### PR DESCRIPTION
In order to start the UI within a browser:
- export RAG_LLM_QUERY_URL=\<IP of the RAG LLM query service\>
- $cd dockers/llm.chatui.service
- In order to install the Gradio python module, you can use venv to do so: 
            python -m venv .venv
            source .venv/bin/activate 
            python3 -m pip install gradio
- Start the Python UI in a browser: $python simple_chat.py