### PR TITLE
Add jira tickets preprocessing

### DIFF
--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -25,8 +25,6 @@ spec:
         env:
         - name: RAG_LLM_QUERY_URL
           value: "http://serveragllm-service.${MODEL_NAMESPACE}.svc.cluster.local:8000"
-        - name: JIRA_BASE_URL
-          value: "https://elotl.atlassian.net"
         - name: USE_CHATBOT_HISTORY
           value: "false"
         resources:

--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/llm-chat:v1.2.1
+        image: elotl/llm-chat:v1.2.1a
         imagePullPolicy: Always
         ports:
         - containerPort: 7860

--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ${MODEL_NAMESPACE}
   labels:
     app: simple-chat
+    elotl-luna: "true"
 spec:
   replicas: 1
   selector:
@@ -17,13 +18,15 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/llm-chat:latest
+        image: elotl/llm-chat:v1.2.1
+        imagePullPolicy: Always
         ports:
         - containerPort: 7860
         env:
         - name: RAG_LLM_QUERY_URL
-          value: "http://serveragllm-service.${MODEL_NAMESPACE}.svc.cluster.local:80"
-
+          value: "http://serveragllm-service.${MODEL_NAMESPACE}.svc.cluster.local:8000"
+        - name: JIRA_BASE_URL
+          value: "https://elotl.atlassian.net"
         - name: USE_CHATBOT_HISTORY
           value: "false"
         resources:

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -46,8 +46,8 @@ spec:
             value: ${MODEL_TEMPERATURE}
           - name: RELEVANT_DOCS
             value: ${RELEVANT_DOCS}
-          - name: IS_JIRA_MODE
-            value: "${IS_JIRA_MODE}"
+          - name: IS_JSON_MODE
+            value: "${IS_JSON_MODE}"
 ---
 apiVersion: v1
 kind: Service

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -15,9 +15,9 @@ spec:
       labels:
         model: serveragllm
       annotations:
-        node.elotl.co/instance-type-regexp: "^t3.xlarge$"
+        # node.elotl.co/instance-type-regexp: "^t3.xlarge$"
         # On GKE use:
-        # node.elotl.co/instance-type-regexp: "^n2-standard-4$"
+        node.elotl.co/instance-type-regexp: "^n2-standard-4$"
     spec:
       containers:
         - name: serveragllm

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -46,6 +46,8 @@ spec:
             value: ${MODEL_TEMPERATURE}
           - name: RELEVANT_DOCS
             value: ${RELEVANT_DOCS}
+          - name: IS_JIRA_MODE
+            value: ${IS_JIRA_MODE}
 ---
 apiVersion: v1
 kind: Service

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -16,10 +16,12 @@ spec:
         model: serveragllm
       annotations:
         node.elotl.co/instance-type-regexp: "^t3.xlarge$"
+        # On GKE use:
+        # node.elotl.co/instance-type-regexp: "^n2-standard-4$"
     spec:
       containers:
         - name: serveragllm
-          image: elotl/serveragllm:v1.2
+          image: elotl/serveragllm:v1.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -47,7 +49,7 @@ spec:
           - name: RELEVANT_DOCS
             value: ${RELEVANT_DOCS}
           - name: IS_JIRA_MODE
-            value: ${IS_JIRA_MODE}
+            value: "${IS_JIRA_MODE}"
 ---
 apiVersion: v1
 kind: Service
@@ -56,10 +58,10 @@ metadata:
   labels:
     app: modelragllmserve
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     model: serveragllm
   ports:
     - name: http
-      port: 80
+      port: 8000
       targetPort: 8000

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -15,9 +15,7 @@ spec:
       labels:
         model: serveragllm
       annotations:
-        # node.elotl.co/instance-type-regexp: "^t3.xlarge$"
-        # On GKE use:
-        node.elotl.co/instance-type-regexp: "^n2-standard-4$"
+        node.elotl.co/instance-type-regexp: "^(t3\.xlarge|n2-standard-4)$"
     spec:
       containers:
         - name: serveragllm

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -7,6 +7,8 @@ metadata:
     elotl-luna: "true"
   annotations:
     node.elotl.co/instance-type-regexp: "^t3.xlarge$"
+    # On GKE use:
+    # node.elotl.co/instance-type-regexp: "^n2-standard-4$"
 spec:
   ttlSecondsAfterFinished: 120
   template:
@@ -14,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: createvectordb
-        image: elotl/createvectordb:v1.2
+        image: elotl/createvectordb:v1.2.1
         imagePullPolicy: Always
         resources:
           requests:

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -6,9 +6,9 @@ metadata:
     app: modeldataingest
     elotl-luna: "true"
   annotations:
-    node.elotl.co/instance-type-regexp: "^t3.xlarge$"
+    # node.elotl.co/instance-type-regexp: "^t3.xlarge$"
     # On GKE use:
-    # node.elotl.co/instance-type-regexp: "^n2-standard-4$"
+    node.elotl.co/instance-type-regexp: "^n2-standard-4$"
 spec:
   ttlSecondsAfterFinished: 120
   template:

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -6,9 +6,7 @@ metadata:
     app: modeldataingest
     elotl-luna: "true"
   annotations:
-    # node.elotl.co/instance-type-regexp: "^t3.xlarge$"
-    # On GKE use:
-    node.elotl.co/instance-type-regexp: "^n2-standard-4$"
+    node.elotl.co/instance-type-regexp: "^(t3\.xlarge|n2-standard-4)$"
 spec:
   ttlSecondsAfterFinished: 120
   template:

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -7,7 +7,6 @@ import requests
 
 # Environment variable setup
 RAG_LLM_QUERY_URL = os.getenv("RAG_LLM_QUERY_URL")
-JIRA_BASE_URL = os.getenv("JIRA_BASE_URL")
 
 if RAG_LLM_QUERY_URL is None:
     print(
@@ -15,14 +14,7 @@ if RAG_LLM_QUERY_URL is None:
     )
     sys.exit(1)
 
-if JIRA_BASE_URL is None:
-    print(
-        "Please set the environment variable, JIRA_BASE_URL (to the base URL of the JIRA instance)"
-    )
-    sys.exit(1)
-
 print("RAG query endpoint, RAG_LLM_QUERY_URL: ", RAG_LLM_QUERY_URL)
-print("JIRA base URL, JIRA_BASE_URL: ", JIRA_BASE_URL)
 
 USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "False") == "True"
 
@@ -30,11 +22,10 @@ print(f"Use history {USE_CHATBOT_HISTORY}")
 
 
 # Function to generate clickable links for JIRA tickets
-def generate_jira_links(answer_key, relevant_tickets):
+def generate_source_links(sources):
     links = []
-    for ticket_id in relevant_tickets:
-        ticket_url = f"{JIRA_BASE_URL}/browse/{ticket_id}"
-        links.append(f'<a href="{ticket_url}" target="_blank">{ticket_id}</a>')
+    for source in sources:
+        links.append(f'<a href="{source}" target="_blank">{source}</a>')
     return links
 
 
@@ -51,8 +42,8 @@ def get_api_response(user_message):
 
             result = result["answer"]
             answer = result.get("answer", "Could not fetch response.")
-            relevant_tickets = result.get("relevant_tickets", [])
-            links = generate_jira_links(answer, relevant_tickets)
+            sources = result.get("sources", [])
+            links = generate_source_links(sources)
             clickable_links = "<br>".join(links)
             return f"{answer}<br><br>Relevant Tickets:<br>{clickable_links}"
         else:

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -1,38 +1,79 @@
 import os
-import requests
 import sys
 import urllib
 
 import gradio as gr
+import requests
 
+# Environment variable setup
 RAG_LLM_QUERY_URL = os.getenv("RAG_LLM_QUERY_URL")
-if  RAG_LLM_QUERY_URL is None:
-    print("Please set environment variable, RAG_LLM_QUERY_URL (to the IP of the RAG + LLM endpoint)")
+JIRA_BASE_URL = os.getenv("JIRA_BASE_URL")
+
+if RAG_LLM_QUERY_URL is None:
+    print(
+        "Please set the environment variable, RAG_LLM_QUERY_URL (to the IP of the RAG + LLM endpoint)"
+    )
     sys.exit(1)
+
+if JIRA_BASE_URL is None:
+    print(
+        "Please set the environment variable, JIRA_BASE_URL (to the base URL of the JIRA instance)"
+    )
+    sys.exit(1)
+
 print("RAG query endpoint, RAG_LLM_QUERY_URL: ", RAG_LLM_QUERY_URL)
+print("JIRA base URL, JIRA_BASE_URL: ", JIRA_BASE_URL)
 
-USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", False)
+USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "False") == "True"
 
+print(f"Use history {USE_CHATBOT_HISTORY}")
+
+
+# Function to generate clickable links for JIRA tickets
+def generate_jira_links(answer_key, relevant_tickets):
+    links = []
+    for ticket_id in relevant_tickets:
+        ticket_url = f"{JIRA_BASE_URL}/browse/{ticket_id}"
+        links.append(f'<a href="{ticket_url}" target="_blank">{ticket_id}</a>')
+    return links
+
+
+# Function to fetch the response from the RAG+LLM API
 def get_api_response(user_message):
     try:
         question = urllib.parse.quote(f"{user_message}")
         response = requests.get(f"{RAG_LLM_QUERY_URL}/answer/{question}")
         if response.status_code == 200:
-            return response.json().get("answer", "Could not fetch response.")
+            result = response.json()
+
+            if "answer" not in result.keys():
+                return "Could not fetch response."
+
+            result = result["answer"]
+            answer = result.get("answer", "Could not fetch response.")
+            relevant_tickets = result.get("relevant_tickets", [])
+            links = generate_jira_links(answer, relevant_tickets)
+            clickable_links = "<br>".join(links)
+            return f"{answer}<br><br>Relevant Tickets:<br>{clickable_links}"
         else:
             return "API Error: Unable to fetch response."
     except requests.RequestException:
         return "API Error: Failed to connect to the backend service."
 
+
+# Chatbot response functions
 def chatbot_response_no_hist(_chatbot, user_message):
-    random_text = get_api_response(user_message)
-    return [[user_message, random_text]], ""
+    response_text = get_api_response(user_message)
+    return [[user_message, response_text]], ""
+
 
 def chatbot_response(history, user_message):
-    random_text = get_api_response(user_message)
-    history.append((user_message, random_text))
+    response_text = get_api_response(user_message)
+    history.append((user_message, response_text))
     return history, ""
 
+
+# Gradio UI setup
 with gr.Blocks() as app:
     with gr.Row():
         with gr.Column(scale=4):
@@ -42,9 +83,15 @@ with gr.Blocks() as app:
 
     if USE_CHATBOT_HISTORY:
         msg.submit(chatbot_response, inputs=[chatbot, msg], outputs=[chatbot, msg])
-        send_button.click(chatbot_response, inputs=[chatbot, msg], outputs=[chatbot, msg])
+        send_button.click(
+            chatbot_response, inputs=[chatbot, msg], outputs=[chatbot, msg]
+        )
     else:
-        msg.submit(chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg])
-        send_button.click(chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg])
+        msg.submit(
+            chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg]
+        )
+        send_button.click(
+            chatbot_response_no_hist, inputs=[chatbot, msg], outputs=[chatbot, msg]
+        )
 
 app.launch()

--- a/dockers/llm.rag.service/Dockerfile
+++ b/dockers/llm.rag.service/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 WORKDIR /serveragllm
 
+COPY __init__.py .
 COPY serveragllm.py .
+COPY serverragllm_jira_cvs_local.py .
 COPY pyproject.toml .
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -54,6 +54,7 @@ def get_answer_with_settings(question, retriever, client, model_id, max_tokens, 
     answer = {
         "answer": completions.choices[0].message.content,
         "relevant_tickets": [r.metadata["key"] for r in docs],
+        "sources": [r.metadata["source"] for r in docs],
     }
     print("Received answer: ", answer)
     return answer

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List
+
+
+def format_context(results: List[Dict[str, Any]]) -> str:
+    """Format search results into context for the LLM"""
+    context_parts = []
+
+    for result in results:
+        # TODO: make metadata keyes configurable
+        ticket_metadata = result.metadata
+        ticket_content = result.page_content
+
+        context_parts.append(
+            f"Key: {ticket_metadata['key']} | Status: {ticket_metadata['status']} - "
+            f"Type: {ticket_metadata['type']}\n"
+            f"Content: {ticket_content}...\n"
+        )
+
+    return "\n\n".join(context_parts)
+
+
+def get_answer_with_settings(question, retriever, client, model_id, max_tokens, model_temperature):
+    SYSTEM_PROMPT = """You are a specialized Jira ticket assistant. Format your responses following these rules:
+                1. Start with the most relevant ticket references
+                2. Provide a clear, direct answer
+                3. Include relevant technical details when present
+                4. Mention related tickets if they provide additional context
+                5. If the information is outdated, mention when it was last updated
+                """
+
+    docs = retriever.invoke(input=question)
+    print(
+        "Number of relevant documents retrieved and that will be used as context for query: ",
+        len(docs),
+    )
+
+    context = format_context(docs)
+
+    print("Sending query to the LLM...")
+    completions = client.chat.completions.create(
+        model=model_id,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": f"Context:\n{context}\n\nQuestion: {question}",
+            },
+        ],
+        max_tokens=max_tokens,
+        temperature=model_temperature,
+        stream=False,
+    )
+
+    answer = {
+        "answer": completions.choices[0].message.content,
+        "relevant_tickets": [r.metadata["key"] for r in docs],
+    }
+    print("Received answer: ", answer)
+    return answer

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -83,7 +83,7 @@ def get_answer(question: Union[str, None]):
         relevant_docs = str_to_int(relevant_docs, "RELEVANT_DOCS")
     print("Using top-k search from Vector DB, k: ", relevant_docs)
 
-    is_jira_mode = os.environ.get("IS_JIRA_MODE", "False") == "True"
+    is_json_mode = os.environ.get("IS_JSON_MODE", "False") == "True"
 
     # retrieve docs relevant to the input question
     docs = retriever.invoke(input=question)
@@ -92,7 +92,7 @@ def get_answer(question: Union[str, None]):
         len(docs),
     )
 
-    if is_jira_mode:
+    if is_json_mode:
         return get_answer_with_settings(
             question,
             retriever,

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -102,7 +102,7 @@ def get_answer(question: Union[str, None]):
         relevant_docs = str_to_int(relevant_docs, "RELEVANT_DOCS")
     print("Using top-k search from Vector DB, k: ", relevant_docs)
 
-    is_jira_mode = os.environ.get("IS_JIRA_MODE")
+    is_jira_mode = os.environ.get("IS_JIRA_MODE", "False") == "True"
 
     # retrieve docs relevant to the input question
     docs = retriever.invoke(input=question)

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -1,20 +1,19 @@
 import os
-import sys
-import boto3
 import pickle
+import sys
 import time
-
 from typing import Union
-from fastapi import FastAPI
-from botocore.exceptions import NoCredentialsError, ClientError
 
-from openai import OpenAI
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+from fastapi import FastAPI
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores import FAISS
+from openai import OpenAI
 
 ########
 # Setup model name and query template parameters
-MICROSOFT_MODEL_ID="microsoft/Phi-3-mini-4k-instruct"
+MICROSOFT_MODEL_ID = "microsoft/Phi-3-mini-4k-instruct"
 MOSAICML_MODEL_ID = "mosaicml/mpt-7b-chat"
 RELEVANT_DOCS_DEFAULT = 2
 MAX_TOKENS_DEFAULT = 64
@@ -28,23 +27,30 @@ Question: {question}
 """
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
+
 def str_to_int(value, name):
     try:
         # Convert the environment variable (or default) to an integer
         int_value = int(value)
     except ValueError:
-        print(f"Error: Value {name} could not be converted to an integer value, please check.")
+        print(
+            f"Error: Value {name} could not be converted to an integer value, please check."
+        )
         sys.exit(1)
     return int_value
+
 
 def str_to_float(value, name):
     try:
         # Convert the environment variable (or default) to an integer
         float_value = float(value)
     except ValueError:
-        print(f"Error: Value {name} could not be converted to an float value, please check.")
+        print(
+            f"Error: Value {name} could not be converted to an float value, please check."
+        )
         sys.exit(1)
     return float_value
+
 
 ########
 # Fetch RAG context for question, form prompt from context and question, and call model
@@ -52,42 +58,45 @@ def get_answer(question: Union[str, None]):
 
     print("Received question: ", question)
 
-    model_id = os.environ.get('MODEL_ID')
+    model_id = os.environ.get("MODEL_ID")
     if model_id == "" or model_id is None:
         model_id = MODEL_ID_DEFAULT
     print("Using Model ID: ", model_id)
 
-    model_temperature = os.environ.get('MODEL_TEMPERATURE')
+    model_temperature = os.environ.get("MODEL_TEMPERATURE")
     if model_temperature == "" or model_temperature is None:
         model_temperature = MODEL_TEMPERATURE_DEFAULT
     else:
-        model_temperature = str_to_float(model_temperature, 'MODEL_TEMPERATURE')
+        model_temperature = str_to_float(model_temperature, "MODEL_TEMPERATURE")
     print("Using Model Temperature: ", model_temperature)
 
-    max_tokens = os.environ.get('MAX_TOKENS')
+    max_tokens = os.environ.get("MAX_TOKENS")
     if max_tokens == "" or max_tokens is None:
         max_tokens = MAX_TOKENS_DEFAULT
     else:
-        max_tokens = str_to_int(max_tokens, 'MAX_TOKENS')
+        max_tokens = str_to_int(max_tokens, "MAX_TOKENS")
     print("Using Max Tokens: ", max_tokens)
 
-    relevant_docs = os.environ.get('RELEVANT_DOCS')
-    if relevant_docs == "" or relevant_docs is None:  
-        relevant_docs = RELEVANT_DOCS_DEFAULT    
+    relevant_docs = os.environ.get("RELEVANT_DOCS")
+    if relevant_docs == "" or relevant_docs is None:
+        relevant_docs = RELEVANT_DOCS_DEFAULT
     else:
-        relevant_docs = str_to_int(relevant_docs, 'RELEVANT_DOCS')
+        relevant_docs = str_to_int(relevant_docs, "RELEVANT_DOCS")
     print("Using top-k search from Vector DB, k: ", relevant_docs)
 
     # retrieve docs relevant to the input question
     docs = retriever.invoke(input=question)
-    print ("Number of relevant documents retrieved and that will be used as context for query: ", len(docs))
+    print(
+        "Number of relevant documents retrieved and that will be used as context for query: ",
+        len(docs),
+    )
 
-    # concatenate relevant docs retrieved to be used as context 
+    # concatenate relevant docs retrieved to be used as context
     allcontext = ""
     for i in range(len(docs)):
         allcontext += docs[i].page_content
     promptstr = template.format(context=allcontext, question=question)
-    
+
     print("Sending query to the LLM...")
     completions = client.chat.completions.create(
         model=model_id,
@@ -102,7 +111,7 @@ def get_answer(question: Union[str, None]):
         temperature=model_temperature,
         stream=False,
     )
-   
+
     answer = completions.choices[0].message.content
     print("Received answer: ", answer)
     return answer
@@ -110,15 +119,20 @@ def get_answer(question: Union[str, None]):
 
 ########
 # Get connection to LLM server
-model_llm_server_url = os.environ.get('MODEL_LLM_SERVER_URL')
+model_llm_server_url = os.environ.get("MODEL_LLM_SERVER_URL")
 if model_llm_server_url is None:
-    model_llm_server_url = "http://llm-model-serve-serve-svc.default.svc.cluster.local:8000"
-    print("Setting environment variable MODEL_LLM_SERVER_URL to default value: ", model_llm_server_url )
-llm_server_url = model_llm_server_url + '/v1'
+    model_llm_server_url = (
+        "http://llm-model-serve-serve-svc.default.svc.cluster.local:8000"
+    )
+    print(
+        "Setting environment variable MODEL_LLM_SERVER_URL to default value: ",
+        model_llm_server_url,
+    )
+llm_server_url = model_llm_server_url + "/v1"
 
 print("Creating an OpenAI client to the hosted model at URL: ", llm_server_url)
 try:
-    client = OpenAI(base_url=llm_server_url, api_key='na')
+    client = OpenAI(base_url=llm_server_url, api_key="na")
 except Exception as e:
     print("Error creating client:", e)
     sys.exit(1)
@@ -127,36 +141,38 @@ except Exception as e:
 # Load vectorstore and get retriever for it
 
 # get env vars needed to access Vector DB
-vectordb_bucket = os.environ.get('VECTOR_DB_S3_BUCKET')
-print ("Using vector DB s3 bucket: ", vectordb_bucket)
+vectordb_bucket = os.environ.get("VECTOR_DB_S3_BUCKET")
+print("Using vector DB s3 bucket: ", vectordb_bucket)
 if vectordb_bucket is None:
     print("Please set environment variable VECTOR_DB_S3_BUCKET")
     sys.exit(1)
 print("Using Vector DB S3 bucket: ", vectordb_bucket)
 
-vectordb_key = os.environ.get('VECTOR_DB_S3_FILE')
-print ("Using vector DB s3 file containing vector store: ", vectordb_key)
+vectordb_key = os.environ.get("VECTOR_DB_S3_FILE")
+print("Using vector DB s3 file containing vector store: ", vectordb_key)
 if vectordb_key is None:
     print("Please set environment variable VECTOR_DB_S3_FILE")
     sys.exit(1)
 print("Using Vector DB S3 file: ", vectordb_key)
 
-relevant_docs = os.environ.get('RELEVANT_DOCS')
-if relevant_docs == "" or relevant_docs is None:  
-    relevant_docs = RELEVANT_DOCS_DEFAULT    
+relevant_docs = os.environ.get("RELEVANT_DOCS")
+if relevant_docs == "" or relevant_docs is None:
+    relevant_docs = RELEVANT_DOCS_DEFAULT
 else:
-    relevant_docs = str_to_int(relevant_docs, 'RELEVANT_DOCS')
+    relevant_docs = str_to_int(relevant_docs, "RELEVANT_DOCS")
 print("Using top-k search from Vector DB, k: ", relevant_docs)
 
 # Use s3 client to read in vector store
-s3_client = boto3.client('s3')
+s3_client = boto3.client("s3")
 response = None
 try:
     response = s3_client.get_object(Bucket=vectordb_bucket, Key=vectordb_key)
 except ClientError as e:
-    print(f"Error accessing object, {vectordb_key} in bucket, {vectordb_bucket}, err: {e}")
+    print(
+        f"Error accessing object, {vectordb_key} in bucket, {vectordb_bucket}, err: {e}"
+    )
     sys.exit(1)
-body = response['Body'].read()
+body = response["Body"].read()
 
 print("Loading Vector DB...\n")
 # needs prereq packages: sentence_transformers and faiss-cpu
@@ -174,6 +190,8 @@ print("Created Vector DB retriever successfully. \n")
 ########
 # Start API service to answer questions
 app = FastAPI()
+
+
 @app.get("/answer/{question}")
 def read_item(question: Union[str, None] = None):
     print(f"Received question: {question}")

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import sys
 import time
-from typing import Union
+from typing import Union, List, Dict, Any
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -52,6 +52,24 @@ def str_to_float(value, name):
     return float_value
 
 
+def format_context(results: List[Dict[str, Any]]) -> str:
+    """Format search results into context for the LLM"""
+    context_parts = []
+
+    for result in results:
+        # TODO: make metadata keyes configurable
+        ticket_metadata = result.metadata
+        ticket_content = result.page_content
+
+        context_parts.append(
+            f"Key: {ticket_metadata['key']} | Status: {ticket_metadata['status']} - "
+            f"Type: {ticket_metadata['type']}\n"
+            f"Content: {ticket_content}...\n"
+        )
+
+    return "\n\n".join(context_parts)
+
+
 ########
 # Fetch RAG context for question, form prompt from context and question, and call model
 def get_answer(question: Union[str, None]):
@@ -84,6 +102,8 @@ def get_answer(question: Union[str, None]):
         relevant_docs = str_to_int(relevant_docs, "RELEVANT_DOCS")
     print("Using top-k search from Vector DB, k: ", relevant_docs)
 
+    is_jira_mode = os.environ.get("IS_JIRA_MODE")
+
     # retrieve docs relevant to the input question
     docs = retriever.invoke(input=question)
     print(
@@ -91,30 +111,64 @@ def get_answer(question: Union[str, None]):
         len(docs),
     )
 
-    # concatenate relevant docs retrieved to be used as context
-    allcontext = ""
-    for i in range(len(docs)):
-        allcontext += docs[i].page_content
-    promptstr = template.format(context=allcontext, question=question)
+    if is_jira_mode:
+        SYSTEM_PROMPT = """You are a specialized Jira ticket assistant. Format your responses following these rules:
+            1. Start with the most relevant ticket references
+            2. Provide a clear, direct answer
+            3. Include relevant technical details when present
+            4. Mention related tickets if they provide additional context
+            5. If the information is outdated, mention when it was last updated
+            """
 
-    print("Sending query to the LLM...")
-    completions = client.chat.completions.create(
-        model=model_id,
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {
-                "role": "user",
-                "content": promptstr,
-            },
-        ],
-        max_tokens=max_tokens,
-        temperature=model_temperature,
-        stream=False,
-    )
+        context = format_context(docs)
 
-    answer = completions.choices[0].message.content
-    print("Received answer: ", answer)
-    return answer
+        print("Sending query to the LLM...")
+        completions = client.chat.completions.create(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": f"Context:\n{context}\n\nQuestion: {question}",
+                },
+            ],
+            max_tokens=max_tokens,
+            temperature=model_temperature,
+            stream=False,
+        )
+
+        answer = {
+            "answer": completions.choices[0].message.content,
+            "relevant_tickets": [r.metadata["key"] for r in docs],
+        }
+        print("Received answer: ", answer)
+        return answer
+
+    else:
+        print("Sending query to the LLM...")
+        # concatenate relevant docs retrieved to be used as context
+        allcontext = ""
+        for i in range(len(docs)):
+            allcontext += docs[i].page_content
+        promptstr = template.format(context=allcontext, question=question)
+
+        completions = client.chat.completions.create(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": promptstr,
+                },
+            ],
+            max_tokens=max_tokens,
+            temperature=model_temperature,
+            stream=False,
+        )
+
+        answer = completions.choices[0].message.content
+        print("Received answer: ", answer)
+        return answer
 
 
 ########

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -1,14 +1,11 @@
 import os
 import pickle
 import sys
-import time
-from typing import Union, List, Dict, Any
+from typing import Any, Dict, List, Union
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from fastapi import FastAPI
-from langchain_community.embeddings import HuggingFaceEmbeddings
-from langchain_community.vectorstores import FAISS
 from openai import OpenAI
 
 ########

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -8,6 +8,8 @@ from botocore.exceptions import ClientError, NoCredentialsError
 from fastapi import FastAPI
 from openai import OpenAI
 
+from common import get_answer_with_settings
+
 ########
 # Setup model name and query template parameters
 MICROSOFT_MODEL_ID = "microsoft/Phi-3-mini-4k-instruct"
@@ -47,24 +49,6 @@ def str_to_float(value, name):
         )
         sys.exit(1)
     return float_value
-
-
-def format_context(results: List[Dict[str, Any]]) -> str:
-    """Format search results into context for the LLM"""
-    context_parts = []
-
-    for result in results:
-        # TODO: make metadata keyes configurable
-        ticket_metadata = result.metadata
-        ticket_content = result.page_content
-
-        context_parts.append(
-            f"Key: {ticket_metadata['key']} | Status: {ticket_metadata['status']} - "
-            f"Type: {ticket_metadata['type']}\n"
-            f"Content: {ticket_content}...\n"
-        )
-
-    return "\n\n".join(context_parts)
 
 
 ########
@@ -109,38 +93,14 @@ def get_answer(question: Union[str, None]):
     )
 
     if is_jira_mode:
-        SYSTEM_PROMPT = """You are a specialized Jira ticket assistant. Format your responses following these rules:
-            1. Start with the most relevant ticket references
-            2. Provide a clear, direct answer
-            3. Include relevant technical details when present
-            4. Mention related tickets if they provide additional context
-            5. If the information is outdated, mention when it was last updated
-            """
-
-        context = format_context(docs)
-
-        print("Sending query to the LLM...")
-        completions = client.chat.completions.create(
-            model=model_id,
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {
-                    "role": "user",
-                    "content": f"Context:\n{context}\n\nQuestion: {question}",
-                },
-            ],
-            max_tokens=max_tokens,
-            temperature=model_temperature,
-            stream=False,
+        return get_answer_with_settings(
+            question,
+            retriever,
+            client,
+            model_id,
+            max_tokens,
+            model_temperature,
         )
-
-        answer = {
-            "answer": completions.choices[0].message.content,
-            "relevant_tickets": [r.metadata["key"] for r in docs],
-        }
-        print("Received answer: ", answer)
-        return answer
-
     else:
         print("Sending query to the LLM...")
         # concatenate relevant docs retrieved to be used as context

--- a/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
+++ b/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
@@ -1,0 +1,154 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "faiss-cpu",
+#     "fastapi",
+#     "langchain-community",
+#     "langchain-huggingface",
+#     "openai",
+#     "uvicorn",
+# ]
+# ///
+
+import pickle
+import sys
+import uvicorn
+
+from functools import partial
+from typing import Any, Dict, List, Union
+
+import click
+from fastapi import FastAPI
+from openai import OpenAI
+
+
+def format_context(results: List[Dict[str, Any]]) -> str:
+    """Format search results into context for the LLM"""
+    context_parts = []
+
+    for result in results:
+        # TODO: make metadata keyes configurable
+        ticket_metadata = result.metadata
+        ticket_content = result.page_content
+
+        context_parts.append(
+            f"Key: {ticket_metadata['key']} | Status: {ticket_metadata['status']} - "
+            f"Type: {ticket_metadata['type']}\n"
+            f"Content: {ticket_content}...\n"
+        )
+
+    return "\n\n".join(context_parts)
+
+
+def get_answer_with_settings(question, retriever, client, model_id, max_tokens, model_temperature):
+    SYSTEM_PROMPT = """You are a specialized Jira ticket assistant. Format your responses following these rules:
+                1. Start with the most relevant ticket references
+                2. Provide a clear, direct answer
+                3. Include relevant technical details when present
+                4. Mention related tickets if they provide additional context
+                5. If the information is outdated, mention when it was last updated
+                """
+
+    docs = retriever.invoke(input=question)
+    print(
+        "Number of relevant documents retrieved and that will be used as context for query: ",
+        len(docs),
+    )
+
+    context = format_context(docs)
+
+    print("Sending query to the LLM...")
+    completions = client.chat.completions.create(
+        model=model_id,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": f"Context:\n{context}\n\nQuestion: {question}",
+            },
+        ],
+        max_tokens=max_tokens,
+        temperature=model_temperature,
+        stream=False,
+    )
+
+    answer = {
+        "answer": completions.choices[0].message.content,
+        "relevant_tickets": [r.metadata["key"] for r in docs],
+    }
+    print("Received answer: ", answer)
+    return answer
+
+
+def setup(
+        file_path: str,
+        relevant_docs: int,
+        llm_server_url:str,
+        model_id: str,
+        max_tokens: int,
+        model_temperature: float,
+):
+    app = FastAPI()
+
+    # Load the object from the pickle file
+    with open(file_path, "rb") as file:
+        print("Loading Vector DB...\n")
+        vectorstore = pickle.load(file)
+
+    # Retriever configuration parameters reference:
+    # https://python.langchain.com/api_reference/community/vectorstores/langchain_community.vectorstores.faiss.FAISS.html#langchain_community.vectorstores.faiss.FAISS.as_retriever
+    retriever = vectorstore.as_retriever(search_kwargs={"k": relevant_docs})
+    print("Created Vector DB retriever successfully. \n")
+
+    print("Creating an OpenAI client to the hosted model at URL: ", llm_server_url)
+    try:
+        client = OpenAI(base_url=llm_server_url, api_key="na")
+    except Exception as e:
+        print("Error creating client:", e)
+        sys.exit(1)
+
+    get_answer = partial(
+        get_answer_with_settings,
+        retriever=retriever,
+        client=client,
+        model_id=model_id,
+        max_tokens=max_tokens,
+        model_temperature=model_temperature,
+    )
+
+    @app.get("/answer/{question}")
+    def read_item(question: Union[str, None] = None):
+        print(f"Received question: {question}")
+        answer = get_answer(question)
+        return {"question": question, "answer": answer}
+
+    return app
+
+
+MICROSOFT_MODEL_ID = "microsoft/Phi-3-mini-4k-instruct"
+MOSAICML_MODEL_ID = "mosaicml/mpt-7b-chat"
+RELEVANT_DOCS_DEFAULT = 2
+MAX_TOKENS_DEFAULT = 64
+MODEL_TEMPERATURE_DEFAULT = 0.01
+
+
+@click.command()
+@click.option("--file-path", required=True)
+@click.option("--relevant-docs", default=RELEVANT_DOCS_DEFAULT)
+@click.option("--llm-server-url", default="http://localhost:11434/v1")
+@click.option("--model-id", default="llama2")
+@click.option("--max-tokens", type=int, default=MAX_TOKENS_DEFAULT)
+@click.option("--model-temperature", type=float, default=MODEL_TEMPERATURE_DEFAULT)
+@click.option("--host", default="127.0.0.1", help="Host for the FastAPI server (default: 127.0.0.1)")
+@click.option("--port", type=int, default=8000, help="Port for the FastAPI server (default: 8000)")
+def run(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature, host, port):
+    # Create the FastAPI app
+    app = setup(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature)
+
+    breakpoint()
+    # Serve the app using Uvicorn
+    uvicorn.run(app, host=host, port=port, reload=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
+++ b/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
@@ -10,6 +10,7 @@
 # ]
 # ///
 
+import os
 import pickle
 import sys
 import uvicorn
@@ -132,22 +133,25 @@ MAX_TOKENS_DEFAULT = 64
 MODEL_TEMPERATURE_DEFAULT = 0.01
 
 
+file_path = os.getenv("FILE_PATH")
+if not file_path:
+    print("Please provide the pickeled vector store path")
+
+relevant_docs = os.getenv("RELEVANT_DOCS", RELEVANT_DOCS_DEFAULT)
+llm_server_url = os.getenv("LLM_SERVER_URL", "http://localhost:11434/v1")
+model_id = os.getenv("MODEL_ID", "llama2")
+max_tokens = int(os.getenv("MAX_TOKENS", MAX_TOKENS_DEFAULT))
+model_temperature = float(os.getenv("MODEL_TEMPERATURE", MODEL_TEMPERATURE_DEFAULT))
+
+app = setup(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature)
+
+
 @click.command()
-@click.option("--file-path", required=True)
-@click.option("--relevant-docs", default=RELEVANT_DOCS_DEFAULT)
-@click.option("--llm-server-url", default="http://localhost:11434/v1")
-@click.option("--model-id", default="llama2")
-@click.option("--max-tokens", type=int, default=MAX_TOKENS_DEFAULT)
-@click.option("--model-temperature", type=float, default=MODEL_TEMPERATURE_DEFAULT)
 @click.option("--host", default="127.0.0.1", help="Host for the FastAPI server (default: 127.0.0.1)")
 @click.option("--port", type=int, default=8000, help="Port for the FastAPI server (default: 8000)")
-def run(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature, host, port):
-    # Create the FastAPI app
-    app = setup(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature)
-
-    breakpoint()
+def run(host, port):
     # Serve the app using Uvicorn
-    uvicorn.run(app, host=host, port=port, reload=True)
+    uvicorn.run("serverragllm_jira_cvs_local:app", host=host, port=port, reload=True)
 
 
 if __name__ == "__main__":

--- a/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
+++ b/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
@@ -16,69 +16,13 @@ import sys
 import uvicorn
 
 from functools import partial
-from typing import Any, Dict, List, Union
+from typing import Union
 
 import click
 from fastapi import FastAPI
 from openai import OpenAI
 
-
-def format_context(results: List[Dict[str, Any]]) -> str:
-    """Format search results into context for the LLM"""
-    context_parts = []
-
-    for result in results:
-        # TODO: make metadata keyes configurable
-        ticket_metadata = result.metadata
-        ticket_content = result.page_content
-
-        context_parts.append(
-            f"Key: {ticket_metadata['key']} | Status: {ticket_metadata['status']} - "
-            f"Type: {ticket_metadata['type']}\n"
-            f"Content: {ticket_content}...\n"
-        )
-
-    return "\n\n".join(context_parts)
-
-
-def get_answer_with_settings(question, retriever, client, model_id, max_tokens, model_temperature):
-    SYSTEM_PROMPT = """You are a specialized Jira ticket assistant. Format your responses following these rules:
-                1. Start with the most relevant ticket references
-                2. Provide a clear, direct answer
-                3. Include relevant technical details when present
-                4. Mention related tickets if they provide additional context
-                5. If the information is outdated, mention when it was last updated
-                """
-
-    docs = retriever.invoke(input=question)
-    print(
-        "Number of relevant documents retrieved and that will be used as context for query: ",
-        len(docs),
-    )
-
-    context = format_context(docs)
-
-    print("Sending query to the LLM...")
-    completions = client.chat.completions.create(
-        model=model_id,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {
-                "role": "user",
-                "content": f"Context:\n{context}\n\nQuestion: {question}",
-            },
-        ],
-        max_tokens=max_tokens,
-        temperature=model_temperature,
-        stream=False,
-    )
-
-    answer = {
-        "answer": completions.choices[0].message.content,
-        "relevant_tickets": [r.metadata["key"] for r in docs],
-    }
-    print("Received answer: ", answer)
-    return answer
+from common import get_answer_with_settings
 
 
 def setup(

--- a/dockers/llm.vdb.service/Dockerfile
+++ b/dockers/llm.vdb.service/Dockerfile
@@ -23,7 +23,10 @@ RUN pip install python-magic
 
 WORKDIR /createvectordb
 
+COPY __init__.py .
 COPY createvectordb.py .
+COPY createvectordb_jira_csv_local.py .
+COPY common.py .
 COPY pyproject.toml .
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -55,13 +55,13 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     return all_chunks, all_metadatas
 
 
-def create_vectordb(local_tmp_dir: str, embedding_model_name: str):
+def create_vectordb(local_tmp_dir: str, embedding_model_name: str, chunk_size: int = 1000, chunk_overlap: int = 200):
     data = load_jsonl_files_from_directory(local_tmp_dir)
 
     # no chunking
     # texts, metadatas = get_documents_with_metadata(data)
     # with chunking texts
-    texts, metadatas = chunk_documents_with_metadata(data)
+    texts, metadatas = chunk_documents_with_metadata(data, chunk_size, chunk_overlap)
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
     vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+from langchain_community.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+
+
+def load_jsonl_files_from_directory(directory):
+    data = []
+    # Loop through all files in the directory
+    for filename in os.listdir(directory):
+        if filename.endswith(".jsonl"):
+            file_path = os.path.join(directory, filename)
+            # Open and read each jsonl file
+            with open(file_path, "r") as file:
+                for line in file:
+                    # Parse each JSON object in the file
+                    data.append(json.loads(line.strip()))
+    return data
+
+
+def create_vectordb(local_tmp_dir: str, embedding_model_name: str):
+    data = load_jsonl_files_from_directory(local_tmp_dir)
+
+    texts = [doc["text"] for doc in data]
+    metadatas = [doc["metadata"] for doc in data]
+
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+    vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
+    return vectorstore

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -5,6 +5,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
 
+EMBEDDING_CHUNK_SIZE_DEFAULT = 1000
+EMBEDDING_CHUNK_OVERLAP_DEFAULT = 100
+
 
 def load_jsonl_files_from_directory(directory):
     data = []
@@ -31,8 +34,7 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     Chunks documents while maintaining alignment between text chunks and metadata
     """
     text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
     )
 
     # Lists to store chunks and corresponding metadata
@@ -55,7 +57,12 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     return all_chunks, all_metadatas
 
 
-def create_vectordb(local_tmp_dir: str, embedding_model_name: str, chunk_size: int = 1000, chunk_overlap: int = 200):
+def create_vectordb(
+    local_tmp_dir: str,
+    embedding_model_name: str,
+    chunk_size: int = EMBEDDING_CHUNK_SIZE_DEFAULT,
+    chunk_overlap: int = EMBEDDING_CHUNK_OVERLAP_DEFAULT,
+):
     data = load_jsonl_files_from_directory(local_tmp_dir)
 
     # no chunking

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
 
@@ -19,11 +20,48 @@ def load_jsonl_files_from_directory(directory):
     return data
 
 
+def get_documents_with_metadata(data):
+    texts = [doc["text"] for doc in data]
+    metadatas = [doc["metadata"] for doc in data]
+    return texts, metadatas
+
+
+def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
+    """
+    Chunks documents while maintaining alignment between text chunks and metadata
+    """
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap
+    )
+
+    # Lists to store chunks and corresponding metadata
+    all_chunks = []
+    all_metadatas = []
+
+    for doc in data:
+        chunks = text_splitter.split_text(doc["text"])
+
+        doc_metadatas = [doc["metadata"].copy() for _ in chunks]
+
+        # This is just to see if it's used or not
+        for i, (chunk, metadata) in enumerate(zip(chunks, doc_metadatas)):
+            metadata["chunk_index"] = i
+            metadata["chunk_total"] = len(chunks)
+
+        all_chunks.extend(chunks)
+        all_metadatas.extend(doc_metadatas)
+
+    return all_chunks, all_metadatas
+
+
 def create_vectordb(local_tmp_dir: str, embedding_model_name: str):
     data = load_jsonl_files_from_directory(local_tmp_dir)
 
-    texts = [doc["text"] for doc in data]
-    metadatas = [doc["metadata"] for doc in data]
+    # no chunking
+    # texts, metadatas = get_documents_with_metadata(data)
+    # with chunking texts
+    texts, metadatas = chunk_documents_with_metadata(data)
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
     vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -9,7 +9,7 @@ def load_jsonl_files_from_directory(directory):
     data = []
     # Loop through all files in the directory
     for filename in os.listdir(directory):
-        if filename.endswith(".jsonl"):
+        if filename.endswith(".jsonl") or filename.endswith(".json"):
             file_path = os.path.join(directory, filename)
             # Open and read each jsonl file
             with open(file_path, "r") as file:

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
 
         vectorstore = FAISS.from_documents(docs, embeddings)
 
-    elif vectordb_input_type == "jira-embedding-json":
+    elif vectordb_input_type == "json-format":
         local_tmp_dir = "/tmp/" + vectordb_file
 
         # create this temp dir if it does not already exist

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -91,10 +91,10 @@ def load_jsonl_files_from_directory(directory):
     data = []
     # Loop through all files in the directory
     for filename in os.listdir(directory):
-        if filename.endswith('.jsonl'):
+        if filename.endswith(".jsonl"):
             file_path = os.path.join(directory, filename)
             # Open and read each jsonl file
-            with open(file_path, 'r') as file:
+            with open(file_path, "r") as file:
                 for line in file:
                     # Parse each JSON object in the file
                     data.append(json.loads(line.strip()))
@@ -149,9 +149,9 @@ if __name__ == "__main__":
         )
     print("Using Embedding Chunk Overlap: ", embedding_chunk_overlap)
 
-    embedding_model_name = os.environ.get(
-        "EMBEDDING_MODEL_NAME", EMBEDDING_MODEL_NAME_DEFAULT
-    )
+    embedding_model_name = os.environ.get("EMBEDDING_MODEL_NAME")
+    if embedding_model_name == "" or embedding_model_name is None:
+        embedding_model_name = EMBEDDING_MODEL_NAME_DEFAULT
     print("Using Embedding Model: ", embedding_model_name)
 
     # Initialize vectorstore and create pickle representation
@@ -237,8 +237,13 @@ if __name__ == "__main__":
         )
 
         data = load_jsonl_files_from_directory(local_tmp_dir)
+
+        print("-------> ", data)
         texts = [doc["text"] for doc in data]
         metadatas = [doc["metadata"] for doc in data]
+
+        print("texts -------> ", texts)
+        print("metadatas -------> ", metadatas)
 
         embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
         vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -238,12 +238,8 @@ if __name__ == "__main__":
 
         data = load_jsonl_files_from_directory(local_tmp_dir)
 
-        print("-------> ", data)
         texts = [doc["text"] for doc in data]
         metadatas = [doc["metadata"] for doc in data]
-
-        print("texts -------> ", texts)
-        print("metadatas -------> ", metadatas)
 
         embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
         vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -12,6 +12,8 @@ from langchain_community.document_loaders.sitemap import SitemapLoader
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
 
+from common import create_vectordb
+
 EMBEDDING_CHUNK_SIZE_DEFAULT = 1000
 EMBEDDING_CHUNK_OVERLAP_DEFAULT = 100
 EMBEDDING_MODEL_NAME_DEFAULT = "sentence-transformers/all-MiniLM-L6-v2"
@@ -85,20 +87,6 @@ def str_to_int(value, name):
         )
         sys.exit(1)
     return int_value
-
-
-def load_jsonl_files_from_directory(directory):
-    data = []
-    # Loop through all files in the directory
-    for filename in os.listdir(directory):
-        if filename.endswith(".jsonl"):
-            file_path = os.path.join(directory, filename)
-            # Open and read each jsonl file
-            with open(file_path, "r") as file:
-                for line in file:
-                    # Parse each JSON object in the file
-                    data.append(json.loads(line.strip()))
-    return data
 
 
 if __name__ == "__main__":
@@ -235,14 +223,7 @@ if __name__ == "__main__":
         print(
             f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}"
         )
-
-        data = load_jsonl_files_from_directory(local_tmp_dir)
-
-        texts = [doc["text"] for doc in data]
-        metadatas = [doc["metadata"] for doc in data]
-
-        embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-        vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
+        vectorstore = create_vectordb(local_tmp_dir, embedding_model_name)
 
     else:
         print("Unknown value for VECTOR_DB_INPUT_TYPE:", vectordb_input_type)

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -223,7 +223,8 @@ if __name__ == "__main__":
         print(
             f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}"
         )
-        vectorstore = create_vectordb(local_tmp_dir, embedding_model_name)
+        vectorstore = create_vectordb(
+            local_tmp_dir, embedding_model_name, embedding_chunk_size, embedding_chunk_overlap)
 
     else:
         print("Unknown value for VECTOR_DB_INPUT_TYPE:", vectordb_input_type)

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -1,21 +1,20 @@
-import json
 import os
 import pickle
 import sys
 
 import boto3
-from botocore.exceptions import ClientError, NoCredentialsError
-from langchain.text_splitter import (CharacterTextSplitter,
-                                     RecursiveCharacterTextSplitter)
+from botocore.exceptions import ClientError
+from langchain.text_splitter import (
+    CharacterTextSplitter,
+    RecursiveCharacterTextSplitter,
+)
 from langchain_community.document_loaders import DirectoryLoader
 from langchain_community.document_loaders.sitemap import SitemapLoader
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
 
-from common import create_vectordb
+from common import create_vectordb, EMBEDDING_CHUNK_SIZE_DEFAULT, EMBEDDING_CHUNK_OVERLAP_DEFAULT
 
-EMBEDDING_CHUNK_SIZE_DEFAULT = 1000
-EMBEDDING_CHUNK_OVERLAP_DEFAULT = 100
 EMBEDDING_MODEL_NAME_DEFAULT = "sentence-transformers/all-MiniLM-L6-v2"
 
 
@@ -224,7 +223,11 @@ if __name__ == "__main__":
             f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}"
         )
         vectorstore = create_vectordb(
-            local_tmp_dir, embedding_model_name, embedding_chunk_size, embedding_chunk_overlap)
+            local_tmp_dir,
+            embedding_model_name,
+            embedding_chunk_size,
+            embedding_chunk_overlap,
+        )
 
     else:
         print("Unknown value for VECTOR_DB_INPUT_TYPE:", vectordb_input_type)

--- a/dockers/llm.vdb.service/createvectordb.py
+++ b/dockers/llm.vdb.service/createvectordb.py
@@ -1,20 +1,20 @@
 import os
+import pickle
 import sys
 
 import boto3
-import pickle
-from botocore.exceptions import NoCredentialsError, ClientError
-
-from langchain_community.vectorstores import FAISS
-from langchain_community.document_loaders.sitemap import SitemapLoader
+from botocore.exceptions import ClientError, NoCredentialsError
+from langchain.text_splitter import (CharacterTextSplitter,
+                                     RecursiveCharacterTextSplitter)
 from langchain_community.document_loaders import DirectoryLoader
+from langchain_community.document_loaders.sitemap import SitemapLoader
+from langchain_community.vectorstores import FAISS
 from langchain_huggingface import HuggingFaceEmbeddings
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.text_splitter import CharacterTextSplitter
 
 EMBEDDING_CHUNK_SIZE_DEFAULT = 1000
 EMBEDDING_CHUNK_OVERLAP_DEFAULT = 100
 EMBEDDING_MODEL_NAME_DEFAULT = "sentence-transformers/all-MiniLM-L6-v2"
+
 
 def list_files_in_s3_folder(bucket_name, folder_name, s3_client):
     """
@@ -23,21 +23,24 @@ def list_files_in_s3_folder(bucket_name, folder_name, s3_client):
     try:
         # List all objects in the specified folder
         response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=folder_name)
-        
-        if 'Contents' not in response:
+
+        if "Contents" not in response:
             print(f"No files found in folder {folder_name} in bucket {bucket_name}")
             return []
-        
+
         file_names = []
-        for content in response['Contents']: 
+        for content in response["Contents"]:
             # ignoring any folders within the top-level folder
-            if not content['Key'].endswith('/'):
-                file_names.append(content['Key']) 
+            if not content["Key"].endswith("/"):
+                file_names.append(content["Key"])
         return file_names
-    
+
     except ClientError as e:
-        print(f"Error listing files in the S3 bucket, {bucket_name}, folder, {folder_name}, err: {e}")
+        print(
+            f"Error listing files in the S3 bucket, {bucket_name}, folder, {folder_name}, err: {e}"
+        )
         return []
+
 
 def download_files_from_s3(bucket_name, folder_name, local_dir):
     """
@@ -45,7 +48,7 @@ def download_files_from_s3(bucket_name, folder_name, local_dir):
     """
 
     # Initialize the S3 client
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
 
     # List and download files from the specified S3 folder
     file_names = list_files_in_s3_folder(bucket_name, folder_name, s3_client)
@@ -54,44 +57,52 @@ def download_files_from_s3(bucket_name, folder_name, local_dir):
         print(f"Found {len(file_names)} file(s) in the folder '{folder_name}'")
         for file_name in file_names:
             local_file_path = os.path.join(local_dir, os.path.basename(file_name))
-            
+
             try:
                 # download file
                 s3_client.download_file(bucket_name, file_name, local_file_path)
-                print(f"Downloaded file, {file_name} successfully to directory, {local_dir}")
+                print(
+                    f"Downloaded file, {file_name} successfully to directory, {local_dir}"
+                )
             except Exception as e:
-                print(f"Error while downloading file, {file_name} from S3, {bucket_name}, err: {e}")
+                print(
+                    f"Error while downloading file, {file_name} from S3, {bucket_name}, err: {e}"
+                )
     else:
         print(f"No files to download in folder {folder_name} in bucket, {bucket_name}.")
-        return 0    
+        return 0
     return len(file_names)
+
 
 def str_to_int(value, name):
     try:
         # Convert the environment variable (or default) to an integer
         int_value = int(value)
     except ValueError:
-        print(f"Error: Value {name} could not be converted to an integer value, please check.")
+        print(
+            f"Error: Value {name} could not be converted to an integer value, please check."
+        )
         sys.exit(1)
     return int_value
 
+
 if __name__ == "__main__":
 
-    vectordb_input_type = os.environ.get('VECTOR_DB_INPUT_TYPE')
+    vectordb_input_type = os.environ.get("VECTOR_DB_INPUT_TYPE")
     if vectordb_input_type is None:
         print("Please set environment variable VECTOR_DB_INPUT_TYPE")
         sys.exit(1)
     print("Using Embedding input type: ", vectordb_input_type)
 
-    vectordb_input_arg = os.environ.get('VECTOR_DB_INPUT_ARG')
+    vectordb_input_arg = os.environ.get("VECTOR_DB_INPUT_ARG")
     if vectordb_input_arg is None:
         print("Please set environment variable VECTOR_DB_INPUT_ARG")
         sys.exit(1)
     print("Using Embedding input arg: ", vectordb_input_arg)
 
-    # This is the bucket that will be used to store both input datasets for 
+    # This is the bucket that will be used to store both input datasets for
     # RAG as well as the Vector DB created from this dataset
-    vectordb_bucket = os.environ.get('VECTOR_DB_S3_BUCKET')
+    vectordb_bucket = os.environ.get("VECTOR_DB_S3_BUCKET")
     if vectordb_bucket is None:
         print("Please set environment variable VECTOR_DB_S3_BUCKET")
         sys.exit(1)
@@ -100,45 +111,53 @@ if __name__ == "__main__":
     # This is the name of the Vector DB file that will be created by this script
     # and will be used by query_rag.py. It has to be unique for each dataset
     # corresponding to a unique VectorDB (or vector store)
-    vectordb_file = os.environ.get('VECTOR_DB_S3_FILE')
+    vectordb_file = os.environ.get("VECTOR_DB_S3_FILE")
     if vectordb_file is None:
         print("Please set environment variable VECTOR_DB_S3_FILE")
         sys.exit(1)
     print("Using Vector DB file: ", vectordb_file)
 
     # This is the chunk size that will be used by the embedding model
-    embedding_chunk_size = os.environ.get('EMBEDDING_CHUNK_SIZE')
-    if embedding_chunk_size == "" or embedding_chunk_size is None:  
+    embedding_chunk_size = os.environ.get("EMBEDDING_CHUNK_SIZE")
+    if embedding_chunk_size == "" or embedding_chunk_size is None:
         embedding_chunk_size = EMBEDDING_CHUNK_SIZE_DEFAULT
     else:
-        embedding_chunk_size = str_to_int(embedding_chunk_size, 'EMBEDDING_CHUNK_SIZE')
+        embedding_chunk_size = str_to_int(embedding_chunk_size, "EMBEDDING_CHUNK_SIZE")
     print("Using Embedding Chunk Size: ", embedding_chunk_size)
 
-    embedding_chunk_overlap = os.environ.get('EMBEDDING_CHUNK_OVERLAP')
-    if embedding_chunk_overlap == "" or embedding_chunk_overlap is None:  
+    embedding_chunk_overlap = os.environ.get("EMBEDDING_CHUNK_OVERLAP")
+    if embedding_chunk_overlap == "" or embedding_chunk_overlap is None:
         embedding_chunk_overlap = EMBEDDING_CHUNK_OVERLAP_DEFAULT
     else:
-        embedding_chunk_overlap = str_to_int(embedding_chunk_overlap, 'EMBEDDING_CHUNK_OVERLAP')
+        embedding_chunk_overlap = str_to_int(
+            embedding_chunk_overlap, "EMBEDDING_CHUNK_OVERLAP"
+        )
     print("Using Embedding Chunk Overlap: ", embedding_chunk_overlap)
-    
-    embedding_model_name = os.environ.get('EMBEDDING_MODEL_NAME', EMBEDDING_MODEL_NAME_DEFAULT)
+
+    embedding_model_name = os.environ.get(
+        "EMBEDDING_MODEL_NAME", EMBEDDING_MODEL_NAME_DEFAULT
+    )
     print("Using Embedding Model: ", embedding_model_name)
-    
+
     # Initialize vectorstore and create pickle representation
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-    if vectordb_input_type == 'text':
-        vectorstore = FAISS.from_texts(vectordb_input_arg, embedding=HuggingFaceEmbeddings())
-    elif vectordb_input_type == 'sitemap':
-        sitemap_loader = SitemapLoader(web_path=vectordb_input_arg, filter_urls=["^((?!.*/v.*).)*$"])
+    if vectordb_input_type == "text":
+        vectorstore = FAISS.from_texts(
+            vectordb_input_arg, embedding=HuggingFaceEmbeddings()
+        )
+    elif vectordb_input_type == "sitemap":
+        sitemap_loader = SitemapLoader(
+            web_path=vectordb_input_arg, filter_urls=["^((?!.*/v.*).)*$"]
+        )
         sitemap_loader.requests_per_second = 1
         docs = sitemap_loader.load()
         print("Count of sitemap docs loaded:", len(docs))
 
         text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size = embedding_chunk_size,
-            chunk_overlap  = embedding_chunk_overlap,
-            length_function = len,
+            chunk_size=embedding_chunk_size,
+            chunk_overlap=embedding_chunk_overlap,
+            length_function=len,
         )
         texts = text_splitter.split_documents(docs)
 
@@ -147,14 +166,14 @@ if __name__ == "__main__":
 
         vectorstore = FAISS.from_documents(texts, embeddings)
 
-    elif vectordb_input_type == 'text-docs':
+    elif vectordb_input_type == "text-docs":
         #######
-        # Download text documents from the S3 bucket 
+        # Download text documents from the S3 bucket
 
-        # This is a folder within the S3 bucket which will contain all the 
-        # text documents that need to be used as the RAG dataset 
+        # This is a folder within the S3 bucket which will contain all the
+        # text documents that need to be used as the RAG dataset
         vectordb_s3_input_dir = vectordb_input_arg
-        
+
         # this is a temporary folder where all the text documents from S3 are stored locally
         # before saving it in the Vector DB
         # TODO (improvement for later) update to using text data from the S3 bucket directly
@@ -165,17 +184,23 @@ if __name__ == "__main__":
             os.makedirs(local_tmp_dir)
 
         # download text docs from S3 bucket + folder (vectordb_s3_input_dir/arg) into this tmp local directory
-        num_files = download_files_from_s3(vectordb_bucket, vectordb_input_arg, local_tmp_dir)
-        print(f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}")
+        num_files = download_files_from_s3(
+            vectordb_bucket, vectordb_input_arg, local_tmp_dir
+        )
+        print(
+            f"Number of files downloaded is {num_files}, local tmp dir is {local_tmp_dir}"
+        )
 
-        loader = DirectoryLoader(local_tmp_dir, glob="**/*")    
+        loader = DirectoryLoader(local_tmp_dir, glob="**/*")
         documents = loader.load()
-        print(f"Number of documents loaded via DirectoryLoader is {len(documents)}") 
+        print(f"Number of documents loaded via DirectoryLoader is {len(documents)}")
 
         # TODO (improvement for later) Allow users to configure chunk size and overlap values
-        text_splitter = CharacterTextSplitter(chunk_size=embedding_chunk_size, chunk_overlap=embedding_chunk_overlap)
+        text_splitter = CharacterTextSplitter(
+            chunk_size=embedding_chunk_size, chunk_overlap=embedding_chunk_overlap
+        )
         docs = text_splitter.split_documents(documents)
-        
+
         # default model name values has been deprecated since 0.2.16, so we choose a specific model
         embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
 
@@ -187,7 +212,9 @@ if __name__ == "__main__":
     pickle_byte_obj = pickle.dumps(vectorstore)
 
     # Persist vectorstore to S3 bucket vectorstores
-    s3_client = boto3.client('s3')
-    s3_client.put_object(Body=pickle_byte_obj, Bucket=vectordb_bucket, Key=vectordb_file)
+    s3_client = boto3.client("s3")
+    s3_client.put_object(
+        Body=pickle_byte_obj, Bucket=vectordb_bucket, Key=vectordb_file
+    )
     print("Uploaded vectordb to", vectordb_bucket, vectordb_file)
     sys.exit(0)

--- a/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
+++ b/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
@@ -19,7 +19,9 @@ from common import create_vectordb
 @click.command()
 @click.argument("local_tmp_dir", type=click.Path(exists=True))
 @click.argument("output_file", type=click.Path())
-@click.argument("embedding_model_name", default="sentence-transformers/all-MiniLM-L6-v2")
+@click.argument(
+    "embedding_model_name", default="sentence-transformers/all-MiniLM-L6-v2"
+)
 def run(local_tmp_dir: str, output_file: str, embedding_model_name: str):
     vectorstore = create_vectordb(local_tmp_dir, embedding_model_name)
 

--- a/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
+++ b/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
@@ -11,37 +11,9 @@
 # Source: dockers/llm.vdb.service/createvectordb.py
 
 import click
-import json
-import os
 import pickle
 
-from langchain_community.vectorstores import FAISS
-from langchain_huggingface import HuggingFaceEmbeddings
-
-
-def load_jsonl_files_from_directory(directory):
-    data = []
-    # Loop through all files in the directory
-    for filename in os.listdir(directory):
-        if filename.endswith(".jsonl"):
-            file_path = os.path.join(directory, filename)
-            # Open and read each jsonl file
-            with open(file_path, "r") as file:
-                for line in file:
-                    # Parse each JSON object in the file
-                    data.append(json.loads(line.strip()))
-    return data
-
-
-def create_vectordb(local_tmp_dir: str, embedding_model_name: str):
-    data = load_jsonl_files_from_directory(local_tmp_dir)
-
-    texts = [doc["text"] for doc in data]
-    metadatas = [doc["metadata"] for doc in data]
-
-    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-    vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
-    return vectorstore
+from common import create_vectordb
 
 
 @click.command()

--- a/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
+++ b/dockers/llm.vdb.service/createvectordb_jira_csv_local.py
@@ -1,0 +1,63 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "click",
+#     "faiss-cpu",
+#     "langchain-community",
+#     "langchain-huggingface",
+# ]
+# ///
+
+# Source: dockers/llm.vdb.service/createvectordb.py
+
+import click
+import json
+import os
+import pickle
+
+from langchain_community.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+
+
+def load_jsonl_files_from_directory(directory):
+    data = []
+    # Loop through all files in the directory
+    for filename in os.listdir(directory):
+        if filename.endswith(".jsonl"):
+            file_path = os.path.join(directory, filename)
+            # Open and read each jsonl file
+            with open(file_path, "r") as file:
+                for line in file:
+                    # Parse each JSON object in the file
+                    data.append(json.loads(line.strip()))
+    return data
+
+
+def create_vectordb(local_tmp_dir: str, embedding_model_name: str):
+    data = load_jsonl_files_from_directory(local_tmp_dir)
+
+    texts = [doc["text"] for doc in data]
+    metadatas = [doc["metadata"] for doc in data]
+
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+    vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
+    return vectorstore
+
+
+@click.command()
+@click.argument("local_tmp_dir", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path())
+@click.argument("embedding_model_name", default="sentence-transformers/all-MiniLM-L6-v2")
+def run(local_tmp_dir: str, output_file: str, embedding_model_name: str):
+    vectorstore = create_vectordb(local_tmp_dir, embedding_model_name)
+
+    pickle_byte_obj = pickle.dumps(vectorstore)
+
+    with open(output_file, "wb") as file:
+        file.write(pickle_byte_obj)
+
+    print(f"Pickle byte object saved to {output_file}")
+
+
+if __name__ == "__main__":
+    run()

--- a/docs/csv_to_json_steps.md
+++ b/docs/csv_to_json_steps.md
@@ -25,7 +25,7 @@ export VECTOR_DB_INPUT_ARG="json-format"
 ## Rag app
 Run rag service with this extra setting
 ```shell
-export IS_JIRA_MODE="True"
+export IS_JSON_MODE="True"
 ```
 
 ## Chat UI app

--- a/docs/csv_to_json_steps.md
+++ b/docs/csv_to_json_steps.md
@@ -1,0 +1,40 @@
+# Process CSV to json and pass to RAG app
+
+## Preparing the data
+Go to `GenAI-infra-stack/scripts` create venv and install deps
+```shell
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+set jira_url in `jira_config.ini` and run
+
+```shell
+uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output_files
+```
+
+upload these files instead of the wiki docs
+
+## Vector store creation
+Run vector store creation with 
+```shell
+export VECTOR_DB_INPUT_ARG="jira-embedding-json"
+```
+
+## Rag app
+Run rag service with this extra setting
+```shell
+export IS_JIRA_MODE="True"
+```
+
+## Chat UI app
+Run chat UI with the same export MODEL_NAMESPACE=... as rag service:
+```shell
+envsubst < simple-chat.yaml | kubectl apply -f -
+```
+
+and port forward to use it:
+```shell
+kubectl port-forward svc/simple-chat-service 7860:7860
+```

--- a/docs/csv_to_json_steps.md
+++ b/docs/csv_to_json_steps.md
@@ -19,7 +19,7 @@ upload these files instead of the wiki docs
 ## Vector store creation
 Run vector store creation with 
 ```shell
-export VECTOR_DB_INPUT_ARG="jira-embedding-json"
+export VECTOR_DB_INPUT_ARG="json-format"
 ```
 
 ## Rag app

--- a/docs/install.md
+++ b/docs/install.md
@@ -212,6 +212,11 @@ We will now setup some environment variables that are needed to enable us to cus
     EMBEDDING_MODEL_NAME (DEFAULT=sentence-transformers/all-MiniLM-L6-v2)
 ```
 
+If You decide to pass to vector db creation a file created using our process_jira_tickets.py script set the following to "True".
+```sh
+    IS_JIRA_MODE (DEFAULT="False")
+```
+
 ### Sample RAG Dataset
 As an example of a RAG dataset, you could use this subset of Wikipedia docs: [https://huggingface.co/datasets/rag-datasets/rag-mini-wikipedia](https://huggingface.co/datasets/rag-datasets/rag-mini-wikipedia)
 This dataset is accompanied with a number of Questions and Answers that can be used to validate RAG functionality.

--- a/docs/install.md
+++ b/docs/install.md
@@ -214,7 +214,7 @@ We will now setup some environment variables that are needed to enable us to cus
 
 If You decide to pass to vector db creation a file created using our process_jira_tickets.py script set the following to "True".
 ```sh
-    IS_JIRA_MODE (DEFAULT="False")
+    IS_JSON_MODE (DEFAULT="False")
 ```
 
 ### Sample RAG Dataset

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,13 @@
 # Prepare csv dump of Jira tickets adjusted for embedding
-```commandline
-uv run csv_to_json.py process_jira_tickets.csv jira_config.ini output.jsonl
+
+[Install UV](https://docs.astral.sh/uv/getting-started/installation/) than create venv and install deps
+```shell
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
 ```
-or
-```commandline
-python csv_to_json.py process_jira_tickets.csv jira_config.ini output.jsonl
+set jira_url in jira_config.ini
+
+```shell
+uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output_files
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Prepare csv dump of Jira tickets adjusted for embedding
+```commandline
+uv run csv_to_json.py process_jira_tickets.csv jira_config.ini output.jsonl
+```
+or
+```commandline
+python csv_to_json.py process_jira_tickets.csv jira_config.ini output.jsonl
+```

--- a/scripts/jira_config.ini
+++ b/scripts/jira_config.ini
@@ -1,0 +1,35 @@
+# Configuration file for Jira embedding preparation.
+# Specify prefixes, substrings, list fields, and other mappings for processing Jira data.
+
+[PrefixFields]
+# Fields with column names starting with the specified prefixes.
+# Example: Columns named "Comment1", "Comment2" will be grouped into "comments_text".
+comments_text = Comment
+attachments_text = Attachment
+
+[SubstringFields]
+# Fields with column names containing the specified substrings (case-insensitive).
+# Example: Columns containing "issue link" in their name will be grouped into "linked_issues_text".
+linked_issues_text = issue link
+
+[ListFields]
+# Fields stored as comma-separated values or lists in a single column.
+# These will be split into lists of individual items and included in composite text.
+fields = Components, Labels
+
+[CompositeTextFields]
+# Fields to include in the composite text (document body).
+# Each key is a user-friendly label, and the value is the corresponding column in the DataFrame.
+# NOTE: Fields from [PrefixFields], [SubstringFields], and [ListFields] will also be included in composite text.
+Title = Summary
+Description = Description
+Status = Status
+Type = Issue Type
+Priority = Priority
+
+[MetadataFields]
+# Fields to include in the document metadata.
+# Each key is a metadata field name, and the value is the corresponding column in the DataFrame.
+key = Issue key
+type = Issue Type
+status = Status

--- a/scripts/jira_config.ini
+++ b/scripts/jira_config.ini
@@ -33,3 +33,7 @@ Priority = Priority
 key = Issue key
 type = Issue Type
 status = Status
+
+[TicketUrl]
+jira_url =  https://elotl.atlassian.net/browse/
+metadata_field = key

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -10,7 +10,7 @@ uv pip install -r requrements.txt
 ```
 
 ```shell
-uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output.jsonl
+uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output_files
 ```
 
 ## Create vector store

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -1,0 +1,26 @@
+# How to run the full process for jira csv locally
+
+## Prepare data
+
+Go to `GenAI-infra-stack/scripts` create venv and install deps
+```shell
+uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output.jsonl
+```
+
+## Create vector store
+Go to `GenAI-infra-stack/dockers/llm.vdb.service`
+
+```shell
+uv run createvectordb_jira_csv_local.py ../../scripts pickled.obj
+```
+
+## Run rag app from local pickled.obj
+
+Run Ollama Open Api compatible local model
+https://ollama.com/blog/openai-compatibility
+
+Go to `GenAI-infra-stack/dockers/llm.rag.service`
+
+```shell
+uv run serverragllm_jira_cvs_local.py --file-path ../llm.vdb.service/pickled.obj
+```

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -8,6 +8,7 @@ uv venv
 source .venv/bin/activate
 uv pip install -r requrements.txt
 ```
+set jira_url in jira_config.ini
 
 ```shell
 uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output_files
@@ -48,7 +49,6 @@ uv pip install -r requrements.txt
 ```
 
 ```shell
-export JIRA_BASE_URL="https://elotl.atlassian.net"
 export RAG_LLM_QUERY_URL="http://127.0.0.1:8000"
  
 uv run simple_chat.py

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -4,6 +4,12 @@
 
 Go to `GenAI-infra-stack/scripts` create venv and install deps
 ```shell
+uv venv
+source .venv/bin/activate
+uv pip install -r requrements.txt
+```
+
+```shell
 uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output.jsonl
 ```
 
@@ -25,4 +31,25 @@ Go to `GenAI-infra-stack/dockers/llm.rag.service`
 export FILE_PATH="../llm.vdb.service/pickled.obj"
 
 uv run serverragllm_jira_cvs_local.py
+```
+
+## Test setup
+```shell
+curl "http://127.0.0.1:8000/answer/How%20to%20install%20luna%20?"
+```
+
+## Run UI
+Go to `GenAI-infra-stack/dockers/llm.chatui.service` create venv and install requirements.
+
+```shell
+uv venv
+source .venv/bin/activate
+uv pip install -r requrements.txt
+```
+
+```shell
+export JIRA_BASE_URL="https://elotl.atlassian.net"
+export RAG_LLM_QUERY_URL="http://127.0.0.1:8000"
+ 
+uv run simple_chat.py
 ```

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -1,12 +1,16 @@
 # How to run the full process for jira csv locally
 
+## Make sure You have 
+- [UV installed](https://docs.astral.sh/uv/getting-started/installation/)
+- [Ollama cli installed](https://ollama.com/download)
+
 ## Prepare data
 
 Go to `GenAI-infra-stack/scripts` create venv and install deps
 ```shell
 uv venv
 source .venv/bin/activate
-uv pip install -r requrements.txt
+uv pip install -r requirements.txt
 ```
 set jira_url in jira_config.ini
 
@@ -45,7 +49,7 @@ Go to `GenAI-infra-stack/dockers/llm.chatui.service` create venv and install req
 ```shell
 uv venv
 source .venv/bin/activate
-uv pip install -r requrements.txt
+uv pip install -r requirements.txt
 ```
 
 ```shell

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -17,7 +17,7 @@ uv run process_jira_tickets.py jira_elotl.csv jira_config.ini output_files
 Go to `GenAI-infra-stack/dockers/llm.vdb.service`
 
 ```shell
-uv run createvectordb_jira_csv_local.py ../../scripts pickled.obj
+uv run createvectordb_jira_csv_local.py ../../scripts/output_files pickled.obj
 ```
 
 ## Run rag app from local pickled.obj

--- a/scripts/jira_csv_local_developement.md
+++ b/scripts/jira_csv_local_developement.md
@@ -22,5 +22,7 @@ https://ollama.com/blog/openai-compatibility
 Go to `GenAI-infra-stack/dockers/llm.rag.service`
 
 ```shell
-uv run serverragllm_jira_cvs_local.py --file-path ../llm.vdb.service/pickled.obj
+export FILE_PATH="../llm.vdb.service/pickled.obj"
+
+uv run serverragllm_jira_cvs_local.py
 ```

--- a/scripts/process_jira_tickets.py
+++ b/scripts/process_jira_tickets.py
@@ -207,7 +207,7 @@ def process_data(input_file: str, config_file: str, output_dir: str):
 
     The input file should be a CSV file containing the data to process.
     The config file should be an INI file with the processing configuration.
-    The output file will be saved in JSONL format.
+    The output file will be saved in JSON format.
     """
     # Load configuration
     click.echo(f"Loading configuration from {config_file}")

--- a/scripts/process_jira_tickets.py
+++ b/scripts/process_jira_tickets.py
@@ -186,7 +186,7 @@ def save_to_jsonl(data: List[Dict], output_file: str):
 @click.argument("input_file", type=click.Path(exists=True))
 @click.argument("config_file", type=click.Path(exists=True))
 @click.argument("output_file", type=click.Path())
-def process_data(input_file: str, config_file: str, output_file: str, preview: bool):
+def process_data(input_file: str, config_file: str, output_file: str):
     """
     Process data from INPUT_FILE using CONFIG_FILE and save to OUTPUT_FILE.
 

--- a/scripts/process_jira_tickets.py
+++ b/scripts/process_jira_tickets.py
@@ -1,0 +1,230 @@
+import json
+from configparser import ConfigParser
+from typing import Any, Dict, List
+
+import click
+import pandas as pd
+
+
+def preprocess_text(text: Any) -> str:
+    """Clean and standardize text content."""
+    if pd.isna(text):
+        return ""
+    return str(text).strip().replace("\n", " ").replace("\r", " ")
+
+
+def get_list_from_field(value: Any) -> List[str]:
+    """Safely convert a field value to a list of strings."""
+    if pd.isna(value):
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if pd.notna(item)]
+    return [str(value)]
+
+
+def extract_prefixed_columns(
+    row: pd.Series, df_columns: List[str], prefix: str
+) -> List[str]:
+    """Extract and concatenate non-empty values from columns starting with a prefix."""
+    return [
+        str(row[col])
+        for col in df_columns
+        if col.startswith(prefix) and pd.notna(row[col])
+    ]
+
+
+def extract_containing_columns(
+    row: pd.Series, df_columns: List[str], substring: str
+) -> List[str]:
+    """Extract and concatenate non-empty values from columns containing a specific substring."""
+    return [
+        str(row[col])
+        for col in df_columns
+        if substring in col.lower() and pd.notna(row[col])
+    ]
+
+
+def extract_composite_text(
+    row: pd.Series, composite_text_fields: Dict[str, str]
+) -> str:
+    """Extract and format fields for composite text."""
+    parts = [
+        f"{field.lower()}: {preprocess_text(row.get(column, ''))}"
+        for field, column in composite_text_fields.items()
+    ]
+    return "\n".join(parts)
+
+
+def extract_metadata(row: pd.Series, metadata_fields: Dict[str, str]) -> Dict[str, str]:
+    """Extract fields for metadata."""
+    metadata = {
+        field.lower(): preprocess_text(row.get(column, ""))
+        for field, column in metadata_fields.items()
+    }
+    return metadata
+
+
+def process_row(
+    row: pd.Series,
+    df_columns: List[str],
+    prefix_fields: Dict[str, str],
+    substring_fields: Dict[str, str],
+    list_fields: List[str],
+    composite_text_fields: Dict[str, str],
+    metadata_fields: Dict[str, str],
+) -> Dict[str, Any]:
+    """Process a single row using the provided configuration."""
+    # Extract prefixed fields
+    prefixed_data = {
+        target_field.lower(): extract_prefixed_columns(row, df_columns, prefix)
+        for target_field, prefix in prefix_fields.items()
+    }
+
+    # Extract substring fields
+    substring_data = {
+        target_field.lower(): extract_containing_columns(row, df_columns, substring)
+        for target_field, substring in substring_fields.items()
+    }
+
+    # Extract list fields
+    list_data = {
+        field.lower(): get_list_from_field(row.get(field, "")) for field in list_fields
+    }
+
+    # Extract composite text
+    composite_text = extract_composite_text(row, composite_text_fields)
+
+    # Add prefixed and substring fields to composite text
+    for field, values in prefixed_data.items():
+        if values:
+            composite_text += f"\n{field}: {' '.join(values)}"
+    for field, values in substring_data.items():
+        if values:
+            composite_text += f"\n{field}: {' '.join(values)}"
+
+    # Add list fields to composite text
+    for field, values in list_data.items():
+        if values:
+            composite_text += f"\n{field.lower()}: {', '.join(values)}"
+
+    # Extract metadata
+    metadata = extract_metadata(row, metadata_fields)
+
+    return {"text": composite_text, "metadata": metadata}
+
+
+def prepare_data_for_embedding(
+    df: pd.DataFrame,
+    prefix_fields: Dict[str, str],
+    substring_fields: Dict[str, str],
+    list_fields: List[str],
+    composite_text_fields: Dict[str, str],
+    metadata_fields: Dict[str, str],
+):
+    """Prepare documents for embedding using the provided configuration."""
+    documents = []
+
+    for _, row in df.iterrows():
+        processed_data = process_row(
+            row=row,
+            df_columns=df.columns,
+            prefix_fields=prefix_fields,
+            substring_fields=substring_fields,
+            list_fields=list_fields,
+            composite_text_fields=composite_text_fields,
+            metadata_fields=metadata_fields,
+        )
+        documents.append(processed_data)
+
+    return documents
+
+
+def load_config(config_file):
+    config = ConfigParser()
+    config.read(config_file)
+
+    # Parse configuration sections into variables
+    prefix_fields = dict(config["PrefixFields"]) if "PrefixFields" in config else {}
+    substring_fields = (
+        dict(config["SubstringFields"]) if "SubstringFields" in config else {}
+    )
+
+    # Handle ListFields specially since we need to split the string
+    list_fields = []
+    if "ListFields" in config and "fields" in config["ListFields"]:
+        fields_str = config["ListFields"]["fields"]
+        if fields_str:
+            list_fields = [f.strip() for f in fields_str.split(",")]
+
+    composite_text_fields = (
+        dict(config["CompositeTextFields"]) if "CompositeTextFields" in config else {}
+    )
+    metadata_fields = (
+        dict(config["MetadataFields"]) if "MetadataFields" in config else {}
+    )
+
+    return {
+        "prefix_fields": prefix_fields,
+        "substring_fields": substring_fields,
+        "list_fields": list_fields,
+        "composite_text_fields": composite_text_fields,
+        "metadata_fields": metadata_fields,
+    }
+
+
+def save_to_jsonl(data: List[Dict], output_file: str):
+    """Save the processed data to a JSONL file."""
+    with open(output_file, "w", encoding="utf-8") as f:
+        for item in data:
+            json.dump(item, f, ensure_ascii=False)
+            f.write("\n")
+
+
+@click.command()
+@click.argument("input_file", type=click.Path(exists=True))
+@click.argument("config_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path())
+def process_data(input_file: str, config_file: str, output_file: str, preview: bool):
+    """
+    Process data from INPUT_FILE using CONFIG_FILE and save to OUTPUT_FILE.
+
+    The input file should be a CSV file containing the data to process.
+    The config file should be an INI file with the processing configuration.
+    The output file will be saved in JSONL format.
+    """
+    # Load configuration
+    click.echo(f"Loading configuration from {config_file}")
+    config = load_config(config_file)
+
+    # Get configuration sections into variables
+    prefix_fields = config["prefix_fields"]
+    substring_fields = config["substring_fields"]
+    list_fields = config["list_fields"]
+    composite_text_fields = config["composite_text_fields"]
+    metadata_fields = config["metadata_fields"]
+
+    # Load DataFrame
+    click.echo(f"Reading data from {input_file}")
+    df = pd.read_csv(input_file)
+
+    # Prepare embedding data
+    click.echo("Processing data...")
+    embedding_data = prepare_data_for_embedding(
+        df=df,
+        prefix_fields=prefix_fields,
+        substring_fields=substring_fields,
+        list_fields=list_fields,
+        composite_text_fields=composite_text_fields,
+        metadata_fields=metadata_fields,
+    )
+
+    # Save to file
+    click.echo(f"Saving processed data to {output_file}")
+    save_to_jsonl(embedding_data, output_file)
+    click.echo(f"Processed {len(embedding_data)} documents")
+
+
+if __name__ == "__main__":
+    process_data()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+click
+pandas


### PR DESCRIPTION
I added :
- a python script that parses jira dump to csv file into a format that can be nicely used during embedding to vector db.
- a mode for vector db creation script to read the jsonl file created by the script and use it for embedding.
- a mode in the rag query app that creates context from text and metadata read from vector db and uses a prompt I was using during my tests.
Ticket id is passed in metadata.
Tested all the pieces locally/manually in ipython.

I still need to perform the e2e test.

What else we can do:
- store ticket data and build wider context for llm before querying 
- enable passing jira addres to create url from ticket id
- parametrize metadata key names on the rag query side
- pass ticket creation data using metadata, so it can be used for future filtering

If we want to be able to iterate fast we need to add tests and enable easily running each piece of the app locally and refactor the code  into smaller pieces than can be easily exchanged and logic is clear

Extra stuff added:
- refactored jira csv pieces, extracted code that could be used in the local version and describe how to run the setup locally.
- moved adding jira urls to the data processing scripts

UI:
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/591e468d-6b4c-4b86-822d-5c98ec83b653">
