### PR TITLE
RAG Query Py Instead of curl

### DIFF
--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -4,7 +4,6 @@ metadata:
   name: serveragllm-deployment
   labels:
     app: modelragllmserve
-    elotl-luna: "true"
 spec:
   replicas: 1
   selector:
@@ -14,6 +13,7 @@ spec:
     metadata:
       labels:
         model: serveragllm
+        elotl-luna: "true"
       annotations:
         node.elotl.co/instance-type-regexp: "^t3.xlarge$"
     spec:
@@ -54,10 +54,10 @@ metadata:
   labels:
     app: modelragllmserve
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     model: serveragllm
   ports:
     - name: http
-      port: 80
+      port: 8000
       targetPort: 8000

--- a/demo/scripts/rag_query.py
+++ b/demo/scripts/rag_query.py
@@ -1,0 +1,25 @@
+import requests
+import urllib.parse
+import json
+
+def main():
+    hostname = "localhost:8000"
+    query = input("Type your query here: ")
+
+    # Encode the question using urllib.parse
+    encoded_question = urllib.parse.quote(query)
+
+    url = f"http://{hostname}/answer/{encoded_question}"
+
+    response = requests.get(url)
+
+    if response.status_code == 200:
+        response = response.text.strip()
+        data = json.loads(response)
+        answer = data['answer']
+        print(f"Answer: {answer}")
+    else:
+        print(f"Error: {response.status_code} - {response.text}")
+
+if __name__ == "__main__":
+    main()

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,7 +92,7 @@ kubectl apply -f ray-service.llm.Phi-3-mini-4k-instruct.autoscale.yaml
 
 ## Model Serve
 
-### Run Port-forward for Model Endpoint
+### Run Port-forward for Model Endpoint (in the background)
 ```sh
 kubectl port-forward svc/llm-model-serve-serve-svc 8000:8000
 ```
@@ -298,15 +298,21 @@ Please note the IP listed in the EXTERNAL-IP column shown in the output of the `
 
 
 ## Query the LLM with RAG
-You can use the CURL command or Postman to access the RAG+LLM service endpoint and ask questions about your RAG dataset.
+You can use the provided demo/scripts/rag_query.py script with port forwarding to query the RAG+LLM service endpoint and ask questions about your RAG dataset.
+
+### Run Port-forward for Model Endpoint (in the background)
+```sh
+nohup kubectl port-forward svc/serveragllm-service 8000:8000 &
+```
+
+Use the script to query the RAG+LLM service
 
 ```sh
-curl -X GET "http://<some-external-IP>/answer/what%20are%20the%20two%20types%20of%20elephants%20in%20Africa?"
-
-{
-"question":"what are the two types of elephants in Africa",
-"answer":"The two types of elephants in Africa are the savanna elephant and the forest elephant."
-}  
+python rag_query.py
+```
+```
+Type your query here: What are the two types of elephants in Africa?
+Answer: The two types of elephants in Africa are the African bush elephant (Loxodonta africana) and the African forest elephant (Loxodonta cyclotis).
 ```
 
 # Uninstallation


### PR DESCRIPTION
This PR does not update any docs, one does need to do port forwarding before using the python script:
```
kubectl port-forward svc/serveragllm-service 8000:8000
```