### PR TITLE
Adding evaluation script for answer comparison during RAG pipeline tuning

### DIFF
--- a/scripts/eval/elotl_jira_questions.txt
+++ b/scripts/eval/elotl_jira_questions.txt
@@ -1,0 +1,25 @@
+What is Luna?
+What is Nova?
+What was the description of the most recent security ticket in Luna?
+Was there a Luna to enable sending user-data to an instance at boot time?
+What was the description of the most recent DR ticket in Nova?
+What cloud providers does Luna work on?
+Can you describe any details about the addition of a promtail sidecar to Luna?
+What are recent updates to the Nova JIT feature?
+What are the two types of elephants in Africa?
+Was there a ticket in Luna to enable sending user-data to an instance at boot time?
+Was there any work done in Luna to enable sending user-data to an instance at boot time?
+Give me the description of a ticket in Luna that deals with sending user-data to an instance at boot time?
+Has the Nova JIT feature been implemented? 
+Can you tell me what the Nova JIT feature is? 
+Had a promtail sidecar been added to Luna?
+What was the most recent type of testing done in Luna?
+When was Nova's DR feature implemented?
+Was the last ticket related to Nova's DR feature?
+Which was the last ticket related to Nova's DR feature?
+Is there a ticket about promtail sidecars in Luna?
+Can you give me the description of the of a Luna ticket about promtail sidecars?
+Can you describe any details about the addition of a promtail sidecar to Luna? 
+What type of work has been done to test the scalability of Nova? 
+What type of cloud providers does Luna not work on?
+Are there any recent updates to the Nova JIT feature?

--- a/scripts/eval/mini_rag_questions.txt
+++ b/scripts/eval/mini_rag_questions.txt
@@ -1,0 +1,50 @@
+Was Abraham Lincoln the sixteenth President of the United States?
+Did Lincoln sign the National Banking Act of 1863?
+Did his mother die of pneumonia?
+How many long was Lincoln's formal education?
+When did Lincoln begin his political career?
+What did The Legal Tender Act of 1862 establish?
+Who suggested Lincoln grow a beard?
+When did the Gettysburg address argue that America was born?
+Did Lincoln beat John C. Breckinridge in the 1860 election?
+Was Abraham Lincoln the first President of the United States?
+When did Lincoln first serve as President?
+Who assassinated Lincoln?
+Did Lincoln win the election of 1860?
+Who was the general in charge at the Battle of Antietam?
+Why did Lincoln issue the Emancipation Proclamation?
+Do scholars rank lincoln among the top three presidents?
+Did lincoln have 18 months of schooling?
+When was the first photgraph of lincoln taken?
+How long was Lincoln's legal Career?
+What trail did Lincoln use a Farmers' Almanac in?
+Did Abraham Lincoln live in the Frontier?
+Did Lincoln's Wife's Family support slavery?
+Who is most noted for his contributions to the theory of molarity and molecular weight?
+Who graduated in ecclesiastical law at the early age of 20 and began to practice?
+Was Lorenzo Romano Amedeo Carlo Avogadro an Italian savant?
+Was Amedeo Avogadro born in Turin August 9th 1776 to a noble ancient family of Piedmont, Italy?
+What happened in 1833?
+Who determined the dependence of the boiling of water with atmospheric pressure?
+Is it true that thermometer had 100 for the freezing point?
+Was Celsius born in Uppsala in Sweden?
+Was Anders Celsius (November 27, 1701 April 25, 1744) a Swedish astronomer?
+Is The Celsius crater on the Moon named after him?
+Who was the first to perform and publish careful experiments aiming at the definition of an international temperature scale on scientific grounds ?
+Can beetles be found in polar regions?
+What are the three sections of a beetle?
+Which defense mechanism uses colour or shape to deceive potential enemies?
+Which type of beetle is a pest of potato plants?
+How can beetle larvae be differentiated from other insect larvae?
+What do beetles eat?
+What are the similarities between beetles and grasshoppers?
+How many species of beetles are there?
+What is the study of beetles called?
+What are prey of various animals including birds and mammals?
+What was given by Aristotle for the hardened shield like forewings?
+Who or what vary greatly in form within the coleoptera?
+When did Coolidge meet and marry Grace Anna Goodhue?
+What period of rapid economic growth did the United States experience during Coolidge's presidency?
+What did Coolidge do after graduating from Amherst?
+When was Coolidge born?
+Where did Coolidge's grandfather had government offices?

--- a/scripts/eval/test_qa.py
+++ b/scripts/eval/test_qa.py
@@ -1,0 +1,90 @@
+import requests
+import json
+from datetime import datetime
+import time
+import sys
+import os
+import urllib
+
+def read_questions(filename):
+    """Read questions from a text file, one per line."""
+    try:
+        with open(filename, 'r', encoding='utf-8') as file:
+            return [line.strip() for line in file if line.strip()]
+    except FileNotFoundError:
+        print(f"Error: Could not find file '{filename}'")
+        sys.exit(1)
+
+def send_question(user_message, endpoint):
+    """Send a single question to the API endpoint."""
+
+    try:
+        question = urllib.parse.quote(f"{user_message}")
+        response = requests.get(f"{endpoint}/answer/{question}")
+        if response.status_code == 200:
+            return response.json().get("answer", "Could not fetch response.")
+        else:
+            return "API Error: Unable to fetch response."
+    except requests.RequestException:
+        return "API Error: Failed to connect to the backend service."
+
+    '''try:
+        response = requests.post(
+            endpoint,
+            json={"question": question},
+            headers={"Content-Type": "application/json"}
+        )
+        response.raise_for_status()
+        return response.json().get('answer', 'No answer provided')
+    except requests.exceptions.RequestException as e:
+        return f"Error: {str(e)}"
+    '''
+
+def save_results(results, output_filename):
+    """Save results to a file in a readable format."""
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"{output_filename}_{timestamp}.txt"
+    
+    with open(filename, 'w', encoding='utf-8') as file:
+        file.write("Q&A Results\n")
+        file.write("=" * 80 + "\n\n")
+        
+        for i, (question, answer) in enumerate(results, 1):
+            file.write(f"Question {i}:\n")
+            file.write("-" * 40 + "\n")
+            file.write(f"{question}\n\n")
+            file.write("Answer:\n")
+            file.write("-" * 40 + "\n")
+            file.write(f"{answer}\n\n")
+            file.write("=" * 80 + "\n\n")
+    
+    return filename
+
+def main():
+    # Configuration
+    RAG_LLM_QUERY_URL = os.getenv("RAG_LLM_QUERY_URL")
+    INPUT_FILE = "mini_rag_questions.txt"  # Replace with your questions file name
+    OUTPUT_FILE_PREFIX = "qa_results"
+    
+    # Read questions
+    print("Reading questions from file...")
+    questions = read_questions(INPUT_FILE)
+    print(f"Found {len(questions)} questions")
+    
+    # Process questions
+    results = []
+    for i, question in enumerate(questions, 1):
+        print(f"Processing question {i} of {len(questions)}...")
+        
+        # Send request and get response
+        answer = send_question(question, RAG_LLM_QUERY_URL)
+        results.append((question, answer))
+        
+        time.sleep(0.5)
+    
+    # Save results
+    output_file = save_results(results, OUTPUT_FILE_PREFIX)
+    print(f"\nResults have been saved to: {output_file}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Quick script to exercise the RAG LLM endpoint for a set of questions. This is intended to be used during RAG pipelines tuning, LLM model configuration, embedding model tuning, etc to check if tuning helps improve answer quality.

This will be extended to include quantitative and qualitative metrics for RAG quality.

Sample run of script:

```
selvik@Selvis-MacBook-Pro eval % python test_qa.py                                    
Reading questions from file...
Found 12 questions
Processing question 1 of 12...
Processing question 2 of 12...
Processing question 3 of 12...
Processing question 4 of 12...
Processing question 5 of 12...
...
Results have been saved to: qa_results_2024-11-27_14-05-35.txt

```