### PR TITLE
Update doc to describe using hf-transfer to improve EKS and GKE image startup time

### DIFF
--- a/demo/llm.gpu.service/block_device_mapping_bottlerocket.json
+++ b/demo/llm.gpu.service/block_device_mapping_bottlerocket.json
@@ -15,7 +15,7 @@
       "VolumeSize": 80,
       "VolumeType": "gp3",
       "Encrypted": false,
-      "SnapshotId": "snap-04c562fdb7a3af82a"
+      "SnapshotId": "snap-09946d545033d96f7"
     }
   }
 ]

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,20 +27,30 @@ helm install --wait --generate-name -n gpu-operator --create-namespace nvidia/gp
 On existing cloud K8s cluster, install Luna as per cloud K8s in the [Luna docs](https://docs.elotl.co/luna/intro/).
 [Download Free trial here](https://www.elotl.co/luna-free-trial.html).
 
-Please see the following two sections for cloud-specific information and/or optimizations.
+Please see the following two sections for EKS and GKE cloud-specific information.
 
 #### EKS
 
-For EKS, you need to specify a larger EBS size w/Luna aws.blockDeviceMapping option.
-* Download [block_device_mapping.json](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.gpu.service/block_device_mapping.json)
+For EKS, you need to specify a larger EBS size w/Luna aws.blockDeviceMapping option.  And you have the choice of configuring Luna
+to use conventional node images (default) or Bottlerocket node images.  Bottlerocket images can be configured for faster node startup time.
+
+##### Conventional Node Images
+
+To specify a larger EBS size for an EKS cluster on which Luna is configured to use conventional node images (default),
+download [block_device_mapping.json](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.gpu.service/block_device_mapping.json)
 and when deploying Luna, include --additional-helm-values set to:
 ```
 --set-file aws.blockDeviceMappings=<path>/block_device_mapping.json
 ```
-* Alternatively on EKS, Luna can be configured to use Bottlerocket with a snapshot volume to prepopulate the nodes it allocates with the ray-ml image, which avoids image download time.
+
+##### Bottlerocket Node Images
+
+When Luna uses conventional node images, downloading the ray-ml image introduces substantial startup time.
+Configuring Luna to instead use Bottlerocket node images with a snapshot volume that prepopulates the nodes
+Luna allocates with the ray-ml image avoids the ray-ml image download time.
 Run [get-user-data.sh](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.gpu.service/get-user-data.sh) with your cluster name and region to produce user-data.toml.
 Download [block_device_mapping_bottlerocket.json](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.gpu.service/block_device_mapping_bottlerocket.json),
-which references the snapshot snap-04c562fdb7a3af82a in us-west-2, built using the instructions
+which references the snapshot snap-09946d545033d96f7 in us-west-2, built using the instructions
 in https://github.com/aws-samples/bottlerocket-images-cache?tab=readme-ov-file#build-ebs-snapshot-with-cached-container-image.
 When deploying Luna, include --additional-helm-values set to:
 ```
@@ -52,8 +62,15 @@ When deploying Luna, include --additional-helm-values set to:
 --set-file aws.userData=<path>/user-data.toml
 ```
 Change the images used by the Ray LLM head and workers in the yaml used in the ray-service installation step below
-from rayproject/ray-ml:2.33.0.914af0-py311 to public.ecr.aws/anyscale/ray-ml:2.33.0-py311
-and remove the line `pip: ["vllm==0.5.4"]`.
+from rayproject/ray-ml:2.33.0.914af0-py311 to 689494258501.dkr.ecr.us-west-2.amazonaws.com/qa-in-a-box:ray-ml-2.33.0-py311-vllm-0.5.4-hfxfr,
+remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines:
+```
+env:
+  - name: HF_HUB_ENABLE_HF_TRANSFER
+    value: "1"
+  - name: HF_HUB_DISABLE_PROGRESS_BARS
+    value: "1"
+```
 
 #### GKE
 
@@ -63,8 +80,15 @@ on your cluster and when deploying Luna, set gcp.nodeServiceAccount to the Luna 
 set gcp.nodeServiceAccount=<CLUSTER_NAME>-elotl@<PROJECT_ID>.iam.gserviceaccount.com
 ```
 Change the images used by the Ray LLM head and workers in the yaml used in the ray-service installation step below
-from rayproject/ray-ml:2.33.0.914af0-py311 to gcr.io/elotl-dev/rayproject/ray-ml:2.33.0.914af0-py311-vllm-0.5.4
-and remove the line `pip: ["vllm==0.5.4"]`.
+from rayproject/ray-ml:2.33.0.914af0-py311 to gcr.io/elotl-dev/rayproject/ray-ml:2.33.0.914af0-py311-vllm-0.5.4-hfxfr,
+remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines:
+```
+env:
+  - name: HF_HUB_ENABLE_HF_TRANSFER
+    value: "1"
+  - name: HF_HUB_DISABLE_PROGRESS_BARS
+    value: "1"
+```
 
 ### Install KubeRay Operator to manage Ray on Cloud K8s Cluster
 ```sh
@@ -76,6 +100,9 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0-rc.0
 
 ## Install Model Serve Stack
 You can choose to install the RayService w/vLLM + Open Source Model Serve Stack either without or with the Ray Autoscaler, as described in the 2 subsections for each of the two models below.  If you install it w/o the Ray Autoscaler, the model serve stack will come up more quickly, but will have a fixed number of workers, configured as 1.  If you install it with the Ray Autoscaler, the model serve stack will start with 0 workers, will scale to 1 worker as the RayService is activated, and will scale to more workers as needed to handle the query load, configured w/a max of 4.
+
+The instructions below describe installing a MosaicML model and a Microsoft model.
+Note that the Microsoft model is of a more recent vintage and loads faster.
 
 ### [MosaicML Open Source Model](https://huggingface.co/mosaicml/mpt-7b-chat)
 Install RayService w/vLLM + MosaicML OS Model w/o Ray Autoscaler

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,7 +27,9 @@ helm install --wait --generate-name -n gpu-operator --create-namespace nvidia/gp
 On existing cloud K8s cluster, install Luna as per cloud K8s in the [Luna docs](https://docs.elotl.co/luna/intro/).
 [Download Free trial here](https://www.elotl.co/luna-free-trial.html).
 
-Please see the following two sections for EKS and GKE cloud-specific information.
+Please note that running the POC on EKS requires
+Luna to be configured to allocate a larger EBS size than the default; this configuration is described in the EKS section below.
+And the EKS and GKE sections below provide instructions to optionally reduce node startup time on those platforms.
 
 #### EKS
 
@@ -63,7 +65,7 @@ When deploying Luna, include --additional-helm-values set to:
 ```
 Change the images used by the Ray LLM head and workers in the yaml used in the ray-service installation step below
 from rayproject/ray-ml:2.33.0.914af0-py311 to 689494258501.dkr.ecr.us-west-2.amazonaws.com/qa-in-a-box:ray-ml-2.33.0-py311-vllm-0.5.4-hfxfr,
-remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines:
+remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines to speed up model download:
 ```
 env:
   - name: HF_HUB_ENABLE_HF_TRANSFER
@@ -81,7 +83,8 @@ set gcp.nodeServiceAccount=<CLUSTER_NAME>-elotl@<PROJECT_ID>.iam.gserviceaccount
 ```
 Change the images used by the Ray LLM head and workers in the yaml used in the ray-service installation step below
 from rayproject/ray-ml:2.33.0.914af0-py311 to gcr.io/elotl-dev/rayproject/ray-ml:2.33.0.914af0-py311-vllm-0.5.4-hfxfr,
-remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines:
+remove the line `pip: ["vllm==0.5.4"]`, and add the following lines below the ray-head and ray-worker image lines
+to speed up model download:
 ```
 env:
   - name: HF_HUB_ENABLE_HF_TRANSFER
@@ -102,7 +105,8 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0-rc.0
 You can choose to install the RayService w/vLLM + Open Source Model Serve Stack either without or with the Ray Autoscaler, as described in the 2 subsections for each of the two models below.  If you install it w/o the Ray Autoscaler, the model serve stack will come up more quickly, but will have a fixed number of workers, configured as 1.  If you install it with the Ray Autoscaler, the model serve stack will start with 0 workers, will scale to 1 worker as the RayService is activated, and will scale to more workers as needed to handle the query load, configured w/a max of 4.
 
 The instructions below describe installing a MosaicML model and a Microsoft model.
-Note that the Microsoft model is of a more recent vintage and loads faster.
+Note that the Microsoft model is of a more recent vintage and loads faster; hence,
+that may be the better choice of the two.
 
 ### [MosaicML Open Source Model](https://huggingface.co/mosaicml/mpt-7b-chat)
 Install RayService w/vLLM + MosaicML OS Model w/o Ray Autoscaler


### PR DESCRIPTION
As titled.

Note that the image load time optimizations for EKS and GKE utilize private snapshots and registries; we can look at making these public as/when needed.