### PR TITLE
Data prep scripts for Zendesk ticket data exported as JSON

### DIFF
--- a/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
+++ b/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
@@ -81,7 +81,7 @@ file_path = os.getenv("FILE_PATH")
 if not file_path:
     print("Please provide the pickeled vector store path")
 
-relevant_docs = os.getenv("RELEVANT_DOCS", RELEVANT_DOCS_DEFAULT)
+relevant_docs = int(os.getenv("RELEVANT_DOCS", RELEVANT_DOCS_DEFAULT))
 llm_server_url = os.getenv("LLM_SERVER_URL", "http://localhost:11434/v1")
 model_id = os.getenv("MODEL_ID", "llama2")
 max_tokens = int(os.getenv("MAX_TOKENS", MAX_TOKENS_DEFAULT))

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -8,11 +8,29 @@ from langchain_huggingface import HuggingFaceEmbeddings
 EMBEDDING_CHUNK_SIZE_DEFAULT = 1000
 EMBEDDING_CHUNK_OVERLAP_DEFAULT = 100
 
+def load_jsonl_files_from_directory(directory):
+    data = []
+    for filename in os.listdir(directory):
+        print("Processing file, ", filename, "..." )
+        if filename.endswith('.json'):
+            with open(os.path.join(directory, filename)) as f:
+                try:
+                    # Try reading as JSONL first
+                    for line in f:
+                        if line.strip():  # Skip empty lines
+                            data.append(json.loads(line.strip()))
+                except json.JSONDecodeError:
+                    # If that fails, try reading as regular JSON
+                    f.seek(0)  # Go back to start of file
+                    data.append(json.load(f))
+    return data
 
+'''
 def load_jsonl_files_from_directory(directory):
     data = []
     # Loop through all files in the directory
     for filename in os.listdir(directory):
+        print("Processing file, ", filename )
         if filename.endswith(".jsonl") or filename.endswith(".json"):
             file_path = os.path.join(directory, filename)
             # Open and read each jsonl file
@@ -21,7 +39,7 @@ def load_jsonl_files_from_directory(directory):
                     # Parse each JSON object in the file
                     data.append(json.loads(line.strip()))
     return data
-
+'''
 
 def get_documents_with_metadata(data):
     texts = [doc["text"] for doc in data]
@@ -42,6 +60,7 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     all_metadatas = []
 
     for doc in data:
+        print("Chunking doc with key, ", doc["metadata"]["key"])
         chunks = text_splitter.split_text(doc["text"])
 
         doc_metadatas = [doc["metadata"].copy() for _ in chunks]
@@ -63,13 +82,16 @@ def create_vectordb(
     chunk_size: int = EMBEDDING_CHUNK_SIZE_DEFAULT,
     chunk_overlap: int = EMBEDDING_CHUNK_OVERLAP_DEFAULT,
 ):
+    print("Load JSON files")
     data = load_jsonl_files_from_directory(local_tmp_dir)
 
     # no chunking
     # texts, metadatas = get_documents_with_metadata(data)
     # with chunking texts
+    print("Start chunking documents")
     texts, metadatas = chunk_documents_with_metadata(data, chunk_size, chunk_overlap)
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+    print("Convert to FAISS vectorstore")
     vectorstore = FAISS.from_texts(texts, embeddings, metadatas=metadatas)
     return vectorstore

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -25,22 +25,6 @@ def load_jsonl_files_from_directory(directory):
                     data.append(json.load(f))
     return data
 
-'''
-def load_jsonl_files_from_directory(directory):
-    data = []
-    # Loop through all files in the directory
-    for filename in os.listdir(directory):
-        print("Processing file, ", filename )
-        if filename.endswith(".jsonl") or filename.endswith(".json"):
-            file_path = os.path.join(directory, filename)
-            # Open and read each jsonl file
-            with open(file_path, "r") as file:
-                for line in file:
-                    # Parse each JSON object in the file
-                    data.append(json.loads(line.strip()))
-    return data
-'''
-
 def get_documents_with_metadata(data):
     texts = [doc["text"] for doc in data]
     metadatas = [doc["metadata"] for doc in data]

--- a/scripts/process_zendesk_tickets.py
+++ b/scripts/process_zendesk_tickets.py
@@ -1,0 +1,187 @@
+# AI Generated script
+
+import os
+import json
+from configparser import ConfigParser
+from typing import Any, Dict, List, Union
+
+import click
+
+def clean_text(text: Any) -> str:
+    """Clean and standardize text content."""
+    if text is None or text == "":
+        return ""
+    return str(text).strip().replace("\n", " ").replace("\r", " ")
+
+
+def parse_list(value: Any) -> List[str]:
+    """Convert a field value to a list of strings."""
+    if not value:  # Handles None, empty string, empty list
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if item]
+    return [str(value)]
+
+
+def extract_field_values(
+    data: Dict[str, Any], 
+    keys: List[str], 
+    matcher: callable
+) -> List[str]:
+    """Extract values from fields that match a given condition."""
+    return [
+        str(data[key])
+        for key in keys
+        if key in data and data[key] and matcher(key)
+    ]
+
+
+def process_item(
+    data: Dict[str, Any],
+    keys: List[str],
+    config: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Process a single JSON item using the provided configuration."""
+    # Extract data using different matching criteria
+    result_text = []
+    
+    # Process composite text fields
+    for field, column in config["composite_text_fields"].items():
+        if column in data and data[column]:
+            result_text.append(f"{field.lower()}: {clean_text(data[column])}")
+    
+    # Process prefix fields
+    for target_field, prefix in config["prefix_fields"].items():
+        values = extract_field_values(
+            data, keys, 
+            lambda k: k.startswith(prefix)
+        )
+        if values:
+            result_text.append(f"{target_field.lower()}: {' '.join(values)}")
+    
+    # Process substring fields
+    for target_field, substring in config["substring_fields"].items():
+        values = extract_field_values(
+            data, keys,
+            lambda k: substring in k.lower()
+        )
+        if values:
+            result_text.append(f"{target_field.lower()}: {' '.join(values)}")
+    
+    # Process list fields
+    for field in config["list_fields"]:
+        if field in data:
+            values = parse_list(data[field])
+            if values:
+                result_text.append(f"{field.lower()}: {', '.join(values)}")
+    
+    # Build metadata
+    metadata = {
+        field.lower(): clean_text(data.get(column, ""))
+        for field, column in config["metadata_fields"].items()
+    }
+    
+    # Add source URL
+    metadata_field = config["metadata_field"]
+    metadata["source"] = config["zendesk_url"] + metadata[metadata_field] + ".json"
+    
+    return {
+        "text": "\n".join(result_text),
+        "metadata": metadata
+    }
+
+
+def prepare_documents(
+    data: Union[Dict[str, Any], List[Dict[str, Any]]],
+    config: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """Prepare documents for embedding using the provided configuration."""
+    # Ensure data is a list
+    items = [data] if isinstance(data, dict) else data
+    
+    # Get all unique keys from the JSON data
+    keys = sorted({key for item in items for key in item})
+    
+    # Process each item
+    return [process_item(item, keys, config) for item in items]
+
+
+def load_config(config_file: str) -> Dict[str, Any]:
+    """Load and parse configuration from INI file."""
+    config = ConfigParser()
+    config.read(config_file)
+    
+    return {
+        "prefix_fields": dict(config["PrefixFields"]) if "PrefixFields" in config else {},
+        "substring_fields": dict(config["SubstringFields"]) if "SubstringFields" in config else {},
+        "list_fields": [
+            f.strip() 
+            for f in config.get("ListFields", "fields", fallback="").split(",")
+            if f.strip()
+        ],
+        "composite_text_fields": dict(config["CompositeTextFields"]) if "CompositeTextFields" in config else {},
+        "metadata_fields": dict(config["MetadataFields"]) if "MetadataFields" in config else {},
+        "zendesk_url": config.get("TicketUrl", "zendesk_url", fallback=""),
+        "metadata_field": config.get("TicketUrl", "metadata_field", fallback=""),
+    }
+
+
+def save_documents(documents: List[Dict], output_dir: str) -> None:
+    """Save documents as individual JSON files."""
+    os.makedirs(output_dir, exist_ok=True)
+    
+    for i, doc in enumerate(documents):
+        output_file = os.path.join(output_dir, f"item_{i}.json")
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(doc, f, ensure_ascii=False, indent=2)
+
+
+@click.command()
+@click.argument("input_file", type=click.Path(exists=True))
+@click.argument("config_file", type=click.Path(exists=True))
+@click.argument("output_dir", type=click.Path())
+def main(input_file: str, config_file: str, output_dir: str) -> None:
+    """
+    Process JSON data using the provided configuration and save results.
+    
+    INPUT_FILE: JSON file containing the data to process
+    CONFIG_FILE: INI configuration file
+    OUTPUT_DIR: Directory to save the processed documents
+    """
+    # Load configuration
+    click.echo(f"Loading configuration from {config_file}")
+    config = load_config(config_file)
+    
+    # Load JSON data
+    click.echo(f"Reading data from {input_file}")
+    data = []
+    with open(input_file, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:  # Skip empty lines
+                try:
+                    json_obj = json.loads(line)
+                    data.append(json_obj)
+                except json.JSONDecodeError as e:
+                    click.echo(f"Warning: Skipping invalid JSON line: {str(e)}")
+                    continue
+    
+    if not data:
+        click.echo("Error: No valid JSON objects found in the input file")
+        return
+    
+    click.echo(f"Found {len(data)} JSON objects")
+    
+    # Process documents
+    click.echo("Processing documents...")
+    documents = prepare_documents(data, config)
+    
+    # Save results
+    click.echo(f"Saving {len(documents)} documents to {output_dir}")
+    save_documents(documents, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/zendesk_config.ini
+++ b/scripts/zendesk_config.ini
@@ -1,0 +1,38 @@
+# Configuration file for Jira embedding preparation.
+# Specify prefixes, substrings, list fields, and other mappings for processing Jira data.
+
+[PrefixFields]
+# Fields with column names starting with the specified prefixes.
+# Example: Columns named "Comment1", "Comment2" will be grouped into "comments_text".
+comments_text = comments
+
+[SubstringFields]
+# Fields with column names containing the specified substrings (case-insensitive).
+# Example: Columns containing "issue link" in their name will be grouped into "linked_issues_text".
+linked_issues_text = issue link
+
+[ListFields]
+# Fields stored as comma-separated values or lists in a single column.
+# These will be split into lists of individual items and included in composite text.
+fields = Components, Labels
+
+[CompositeTextFields]
+# Fields to include in the composite text (document body).
+# Each key is a user-friendly label, and the value is the corresponding column in the DataFrame.
+# NOTE: Fields from [PrefixFields], [SubstringFields], and [ListFields] will also be included in composite text.
+Title = subject
+Description = description
+Status = status
+Type = type
+Priority = priority
+
+[MetadataFields]
+# Fields to include in the document metadata.
+# Each key is a metadata field name, and the value is the corresponding column in the DataFrame.
+key = id
+type = type
+status = status
+
+[TicketUrl]
+zendesk_url =  https://zendesk.com/api/v2/tickets/
+metadata_field = key


### PR DESCRIPTION
The script in the PR is used to convert generic JSON output into the format expected by "Elotl's Create Vector DB" image: 

Usage of this script:
```
uv venv
source .venv/bin/activate
uv pip install -r requirements.txt
uv run process_zendesk_tickets.py <path_to_zendesk_exported>.json zendesk_config.ini zendesk_dataprep_output
```

Drive by:
- `load_jsonl_files_from_directory` did not work for regular JSON files. (JSONL format expects one JSON object per line) So this function has been updated to handle both JSONL and JSON formats.
- Minor fixes needed to correctly run the e2e vector db creation and RAG LLM serving locally on a laptop.
- Logs/Prints to ensure we can track progress of the vector db creation and chunking process. Takes 15 mins on my Apple M2 Pro laptop (16GB memory).
