### PR TITLE
Update S3 download file method to use pagination to download all files (when > 999)

### DIFF
--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: serveragllm
-          image: elotl/serveragllm:v1.2.2
+          image: elotl/serveragllm:v1.2.3
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/demo/llm.vdb.service/createvdb.yaml
+++ b/demo/llm.vdb.service/createvdb.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: createvectordb
-        image: elotl/createvectordb:v1.2.2
+        image: elotl/createvectordb:v1.2.3
         imagePullPolicy: Always
         resources:
           requests:

--- a/dockers/llm.vdb.service/check_files_in_s3_bucket.py
+++ b/dockers/llm.vdb.service/check_files_in_s3_bucket.py
@@ -1,0 +1,52 @@
+import boto3
+from botocore.exceptions import ClientError
+import argparse
+from typing import List, Optional
+from createvectordb import list_files_in_s3_folder
+
+def main():
+    """
+    Main function to run the S3 file listing script.
+    Accepts command line arguments for bucket name and folder prefix.
+    """
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description='List all files in an S3 bucket folder with pagination')
+    parser.add_argument('--bucket', required=True, help='Name of the S3 bucket')
+    parser.add_argument('--folder', required=True, help='Folder prefix in the bucket')
+    parser.add_argument('--profile', help='AWS profile name (optional)', default=None)
+    parser.add_argument('--region', help='AWS region (optional)', default='us-east-1')
+    
+    args = parser.parse_args()
+    
+    try:
+        # Set up AWS session with optional profile
+        if args.profile:
+            session = boto3.Session(profile_name=args.profile, region_name=args.region)
+        else:
+            session = boto3.Session(region_name=args.region)
+        
+        # Create S3 client
+        s3_client = session.client('s3')
+        
+        # Call the listing function
+        files = list_files_in_s3_folder(args.bucket, args.folder, s3_client)
+        
+        # Print summary and sample results
+        if files:
+            print(f"Summary of files in {args.bucket}/{args.folder}:")
+            print(f"Total files found: {len(files)}")
+            print("\nFirst 5 files:")
+            for file in files[:5]:
+                print(file)
+            
+            print(f"\nLast 5 files:")
+            for file in files[-5:]:
+                print(file)
+            
+            print(f"\nFinal count confirmation: {len(files)} files found")
+            
+    except Exception as e:
+        print(f"Error: {str(e)}")
+
+if __name__ == "__main__":
+    main()

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -57,6 +57,7 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
         all_chunks.extend(chunks)
         all_metadatas.extend(doc_metadatas)
 
+    print("Number of chunks created: ", len(all_chunks))
     return all_chunks, all_metadatas
 
 


### PR DESCRIPTION
Changes in this PR:

- Existing version of the S3 download code was only downloading the first 999 files in a bucket.
- This PR fixes this limitation and ensures that all top-level files in the bucket are downloaded and used in the vector DB creation.
- Also added a script to exercise this new method and verify the number of files in the user-provided s3 bucket. This will allow us to do a quick validation before running the vector DB creation job.

- This script can be invoked like this:
`$ uv run check_files_in_s3_bucket.py --bucket $VECTOR_DB_S3_BUCKET --folder zendesk-input  --region us-west-2`