### PR TITLE
Improve logging

### DIFF
--- a/demo/llm.chatui.service/pv-and-pvc.yaml
+++ b/demo/llm.chatui.service/pv-and-pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: simple-chat-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /mnt/data/simple-chat-logs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: simple-chat-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -33,6 +33,13 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        volumeMounts:
+        - name: log-storage
+          mountPath: /app/logs
+      volumes:
+      - name: log-storage
+        persistentVolumeClaim:
+          claimName: simple-chat-pvc
 ---
 apiVersion: v1
 kind: Service

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -5,20 +5,34 @@ import urllib
 import gradio as gr
 import requests
 
+import logging
+
+# When running locally: export CHATUI_LOGS_PATH=logs/chatui.log
+log_file_path = os.getenv("CHATUI_LOGS_PATH") or "/app/logs/chatui.log"
+os.makedirs(os.path.dirname(log_file_path), exist_ok=True)  # Ensure log directory exists
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler(log_file_path),  # Log to file
+        logging.StreamHandler()             # Also log to console
+    ]
+)
+
 # Environment variable setup
 RAG_LLM_QUERY_URL = os.getenv("RAG_LLM_QUERY_URL")
 
 if RAG_LLM_QUERY_URL is None:
-    print(
+    logging.error(
         "Please set the environment variable, RAG_LLM_QUERY_URL (to the IP of the RAG + LLM endpoint)"
     )
     sys.exit(1)
 
-print("RAG query endpoint, RAG_LLM_QUERY_URL: ", RAG_LLM_QUERY_URL)
+logging.info(f"RAG query endpoint, RAG_LLM_QUERY_URL: {RAG_LLM_QUERY_URL}")
 
 USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "False") == "True"
 
-print(f"Use history {USE_CHATBOT_HISTORY}")
+logging.info(f"Use history {USE_CHATBOT_HISTORY}")
 
 
 # Function to generate clickable links for JIRA tickets
@@ -65,7 +79,7 @@ def chatbot_response(history, user_message):
 
 
 def submit_rating(rating, user_message, bot_response):
-    print(f"User rating: {rating}\nQuestion: {user_message}\nAnswer: {bot_response}")
+    logging.info(f"User rating: {rating}\nQuestion: {user_message}\nAnswer: {bot_response}")
     # Hide the rating slider and submit button after submission
     return gr.update(visible=False), gr.update(visible=False)
 

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -6,6 +6,7 @@ import gradio as gr
 import requests
 
 import logging
+from logging.handlers import TimedRotatingFileHandler
 
 # When running locally: export CHATUI_LOGS_PATH=logs/chatui.log
 log_file_path = os.getenv("CHATUI_LOGS_PATH") or "/app/logs/chatui.log"
@@ -14,7 +15,8 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
-        logging.FileHandler(log_file_path),  # Log to file
+         # Log to file, rotate every 1H and store last 24 files == 24H data
+        TimedRotatingFileHandler(log_file_path, when='h', interval=1, backupCount=24), 
         logging.StreamHandler()             # Also log to console
     ]
 )

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -55,6 +55,7 @@ def get_answer_with_settings(question, retriever, client, model_id, max_tokens, 
         "answer": completions.choices[0].message.content,
         "relevant_tickets": [r.metadata["key"] for r in docs],
         "sources": [r.metadata["source"] for r in docs],
+        "context": context,  # TODO: if this is big consider logging context here and sending some reference id to UI
     }
     print("Received answer: ", answer)
     return answer


### PR DESCRIPTION
In the first iteration of logging context:
- I added PVC and use the directory inside simple chat app (when running locally an env var needs to be set - look for comment in chat py file)
- Logs are rotated every hour and at the moment we only keep logs from last 24 hours
- I added context to the response from rag service
- I use the context from the response if it exists and log it together with the rating

You need to kubectl apply -f pv-and-pvc.yaml and also apply new changed simple chat.

This should do the job for now, but:
- Ideally I wouldn't send the context from service to chat ui. I would add logging question answer and context together with some uuid inside the rag service and send the uuid to chat ui. In chat ui I would log this uuid and later we could connect rating with other data.

Tested only just locally. And tested that PVC yaml can be applied in k8s.