### PR TITLE
Fixes to Chat Auth to correctly route to Chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * [Creation of the Vector Store](docs/install.md#creation-of-the-vector-store)
 * [Install the RAG & LLM querying service](docs/install.md#setup-rag-llm-service)
 * [Send a question to your LLM](docs/install.md#query-the-llm-with-rag)
-* [Uninstall](docs/install.md#uninstallation)
+* [Uninstall](docs/install.md#uninstall)
 
 Jump to complete install doc available [here](docs/install.md).
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 * [Model Serving](docs/install.md#model-serve)
 * [Retrieval Augmented Generation using FAISS](docs/install.md#retrieval-augmented-generation-rag-using-faiss)
 * [Creation of the Vector Store](docs/install.md#creation-of-the-vector-store)
-* [Install the RAG & LLM querying service](docs/install.md#setup-rag-llm-service)
-* [Send a question to your LLM](docs/install.md#query-the-llm-with-rag)
+* [Install the RAG & LLM querying service](docs/install.md#setup-rag--llm-service)
+* [Send a question to your LLM with RAG](docs/install.md#query-the-llm-with-rag)
+* [Query your LLM with RAG using a Chat UI](docs/install.md#query-the-llm-with-rag-using-a-chat-ui)
 * [Uninstall](docs/install.md#uninstall)
 
 Jump to complete install doc available [here](docs/install.md).

--- a/demo/llm.chatui.service/auth-proxy.yml
+++ b/demo/llm.chatui.service/auth-proxy.yml
@@ -39,7 +39,7 @@ data:
   # cat .htpasswd | base64
   # myuser:elotl
 
-  .htpasswd: bXl1c2VyOiRhcHIxJG9mMmRwcm92JC5BTTZiU0xLZzR4aDNzVS82S0s2ejEK
+  .htpasswd: ZWxvdGw6JGFwcjEkRmtKeUFMWjMkYjd5WXdBdmhHbmtTSjN2QTdCOXlGMAo=
 
 ---
 # auth-proxy-deployment.yaml

--- a/demo/llm.chatui.service/pv-and-pvc.yaml
+++ b/demo/llm.chatui.service/pv-and-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simple-chat-pv
 spec:
   capacity:
-    storage: 1Gi
+    storage: 20Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
@@ -20,4 +20,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 20Gi

--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/llm-chat:v1.2.2
+        image: elotl/llm-chat:v1.2.5
         imagePullPolicy: Always
         ports:
         - containerPort: 7860

--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: serveragllm
-          image: elotl/serveragllm:v1.2.3
+          image: elotl/serveragllm:v1.2.4
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -15,8 +15,8 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
-         # Log to file, rotate every 1H and store last 24 files == 24H data
-        TimedRotatingFileHandler(log_file_path, when='h', interval=1, backupCount=24), 
+         # Log to file, rotate every 1H and store files from last 24 hrs * 7 days files == 168H data
+        TimedRotatingFileHandler(log_file_path, when='h', interval=1, backupCount=168),
         logging.StreamHandler()             # Also log to console
     ]
 )

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -124,4 +124,4 @@ with gr.Blocks() as app:
         outputs=[rating_slider, submit_rating_btn],
     )
 
-app.launch()
+app.launch(server_name="0.0.0.0")

--- a/docs/install.md
+++ b/docs/install.md
@@ -414,10 +414,10 @@ Answer: The two types of elephants in Africa are the African bush elephant (Loxo
 
 ### Generate and setup a password for your Chat UI
 
-Run the tool locally htpasswd locally.
+Run the tool `htpasswd` locally to generate credentials needed for authentication
 
 ```sh
-htpasswd -c .htpasswd your_chosen_username
+htpasswd -c .htpasswd <your_chosen_username>
 ```
 
 Convert the encrypted password to base64 encoding to be used in a K8s secret:


### PR DESCRIPTION
Changes in this PR include:

* Fixes to Chat Auth to correctly route to Chat UI (Gradio app needed to be launched at 0.0.0.0 instead of the default value). This fixes routing from the user-auth screen to the actual Chat UI app. 
* Increase log persistence to 7 days from 24 hrs
* Increase PV size for Chat logs to 20G from 1G
* Update docs to include setup, configuration and use of Chat UI
* Also updated all 3 apps (vector db creation, serveragllm and chat UI) to manually created latest image versions. (Once I get it working e2e will update image versions to be uniform across all 3 images)