### PR TITLE
Handle "context" and "question" hallucinations being appended to the generated answer

### DIFF
--- a/demo/llm.rag.service/chat-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/chat-serveragllmpluslb.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: serveragllm
-          image: elotl/serveragllm:v1.3.8
+          image: elotl/serveragllm:v1.3.11
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -51,19 +51,30 @@ def get_answer_with_settings(question, retriever, client, model_id, max_tokens, 
     logging.info(f"Context after formatting: {context}")
 
     logging.info("Calling chat completions for JSON model...")
-    completions = client.chat.completions.create(
-        model=model_id,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {
-                "role": "user",
-                "content": f"Context:\n{context}\n\nQuestion: {question}",
-            },
-        ],
-        max_tokens=max_tokens,
-        temperature=model_temperature,
-        stream=False,
-    )
+    try:
+        completions = client.chat.completions.create(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": f"Context:\n{context}\n\nQuestion: {question}",
+                },
+            ],
+            max_tokens=max_tokens,
+            temperature=model_temperature,
+            stream=False,
+        )
+    except Exception as e:
+        # Handle any error
+        logging.error(f"An unexpected error occurred: {e}")
+        errorToUI = {
+            "answer": f"Please try another question. Received error from LLM invocation: {e}",
+            "relevant_tickets": [],
+            "sources": [],
+            "context": context,
+        }
+        return errorToUI
 
     generated_answer = completions.choices[0].message.content
 

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -70,8 +70,9 @@ def get_answer_with_settings(question, retriever, client, model_id, max_tokens, 
     # Handle common hallucinations observed:
     #    1. Added-Context hallucination
     #    2. Added-Question hallucination
+    #    3. Added-Context hallucination just labelled as "Content" (instead of Context like 1)
     logging.info(f"Removing any observed hallucinations in the generated answer: {generated_answer}")
-    labels_to_trim = ["Context:", "Question:"]
+    labels_to_trim = ["Context:", "Question:", "Content:"]
     answer = generated_answer
 
     for label in labels_to_trim:


### PR DESCRIPTION
This PR includes the following changes:
 * Handle hallucinated context being added to generated answers and is preceeded by the label: "Content"
 * Manually remove new-question hallucination which seems to be preceeded by the label "Question:" 
 * Propagate any LLM API errors to the UI (this is otherwise causing a generic API response error to be received and displayed in the UI)
