### PR TITLE
Update Chat UI to display history of question and answers

### DIFF
--- a/demo/llm.chatui.service/simple-chat.yaml
+++ b/demo/llm.chatui.service/simple-chat.yaml
@@ -27,7 +27,7 @@ spec:
         - name: RAG_LLM_QUERY_URL
           value: "http://serveragllm-service.default.svc.cluster.local:8000"
         - name: USE_CHATBOT_HISTORY
-          value: "false"
+          value: "True"
         resources:
           requests:
             cpu: "200m"

--- a/dockers/llm.chatui.service/simple_chat.py
+++ b/dockers/llm.chatui.service/simple_chat.py
@@ -32,7 +32,7 @@ if RAG_LLM_QUERY_URL is None:
 
 logging.info(f"RAG query endpoint, RAG_LLM_QUERY_URL: {RAG_LLM_QUERY_URL}")
 
-USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "False") == "True"
+USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "True") == "True"
 
 logging.info(f"Use history {USE_CHATBOT_HISTORY}")
 


### PR DESCRIPTION
Currently the QA in a box UI only shows the current question typed in by the user and corresponding answer generated by the LLM. Prospective customers wanted to be able to view prior questions, so they could use context from the generated answer in a follow up questions.  

This PR, updates the Chat UI to show the history of all questions asked by the user during the current session. 

This is implemented by setting chat history to be enabled by default.

Note that this updates only the display. Prior questions and answers are not sent to the LLM as context for a subsequent question.  

