### PR TITLE
Put metadata to each chunk

### DIFF
--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -30,7 +30,7 @@ def get_documents_with_metadata(data):
     return texts, metadatas
 
 
-def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
+def chunk_documents_with_metadata(data, chunk_size, chunk_overlap):
     """
     Chunks documents while maintaining alignment between text chunks and metadata
     """
@@ -60,7 +60,7 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     return all_chunks, all_metadatas
 
 
-def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, chunk_overlap=200):
+def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size, chunk_overlap):
     """
     Splits documents into smaller text chunks while preserving alignment with metadata.
     Additionally, each chunk is enriched by embedding its corresponding metadata into the text.

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -68,7 +68,7 @@ def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, ch
     # TODO: find a better way to find the biggest metadata
     max_size_of_metadata = 0
     for doc in data:
-        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"]])
+        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"].items() if value])
         max_size_of_metadata = max(max_size_of_metadata, len(meta_enhancement))
 
     print(f"Biggest metada has {max_size_of_metadata} characters.")
@@ -94,7 +94,7 @@ def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, ch
 
         doc_metadatas = [doc["metadata"].copy() for _ in chunks]
 
-        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"]])
+        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"].items() if value])
 
         for i, (chunk, metadata) in enumerate(zip(chunks, doc_metadatas)):
             chunks_enriched_with_metadata.append(chunk + "\n" + meta_enhancement)
@@ -120,8 +120,11 @@ def create_vectordb_from_data(
     # texts, metadatas = get_documents_with_metadata(data)
 
     # with chunking texts
+    # texts, metadatas = chunk_documents_with_metadata(data, chunk_size, chunk_overlap)
+
+    # with adding metadata to text
     print("Start chunking documents")
-    texts, metadatas = chunk_documents_with_metadata(data, chunk_size, chunk_overlap)
+    texts, metadatas = chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size, chunk_overlap)
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
     print("Convert to FAISS vectorstore")

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -60,6 +60,41 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
     return all_chunks, all_metadatas
 
 
+def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, chunk_overlap=200):
+    """
+    Chunks documents while maintaining alignment between text chunks and metadata
+    """
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+
+    # Lists to store chunks and corresponding metadata
+    all_chunks = []
+    all_metadatas = []
+
+    for doc in data:
+        print("Chunking doc with key/ticket ID, ", doc["metadata"].get("ticket") or doc["metadata"].get("key"))
+        chunks = text_splitter.split_text(doc["text"])
+        chunks_enriched_with_metadata = []
+
+        doc_metadatas = [doc["metadata"].copy() for _ in chunks]
+
+        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"]])
+
+        for i, (chunk, metadata) in enumerate(zip(chunks, doc_metadatas)):
+            chunks_enriched_with_metadata.append(chunk + "\n" + meta_enhancement)
+
+            # This is just to see if it's used or not
+            metadata["chunk_index"] = i
+            metadata["chunk_total"] = len(chunks)
+
+        all_chunks.extend(chunks_enriched_with_metadata)
+        all_metadatas.extend(doc_metadatas)
+
+    print("Number of chunks created: ", len(all_chunks))
+    return all_chunks, all_metadatas
+
+
 def create_vectordb_from_data(
     data,
     embedding_model_name: str,

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -62,8 +62,23 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
 
 def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, chunk_overlap=200):
     """
-    Chunks documents while maintaining alignment between text chunks and metadata
+    Chunks documents while maintaining alignment between text chunks and metadata and adds
+    metadata to text, so each chunk ahs metadata inside
     """
+    # TODO: find a better way to find the biggest metadata
+    max_size_of_metadata = 0
+    for doc in data:
+        meta_enhancement = "\n".join([f"{key}: {value}" for key, value in doc["metadata"]])
+        max_size_of_metadata = max(max_size_of_metadata, len(meta_enhancement))
+
+    print(f"Biggest metada has {max_size_of_metadata} characters.")
+    effective_chunk_size = chunk_size - max_size_of_metadata
+    print(f"Effective chunk size will be {effective_chunk_size}")
+
+    # TODO: handle better
+    if effective_chunk_size <= 0:
+        raise "Use bigger chunk size"
+
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=chunk_size, chunk_overlap=chunk_overlap
     )

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -62,8 +62,13 @@ def chunk_documents_with_metadata(data, chunk_size=1000, chunk_overlap=200):
 
 def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size=1000, chunk_overlap=200):
     """
-    Chunks documents while maintaining alignment between text chunks and metadata and adds
-    metadata to text, so each chunk ahs metadata inside
+    Splits documents into smaller text chunks while preserving alignment with metadata.
+    Additionally, each chunk is enriched by embedding its corresponding metadata into the text.
+
+    The method determines the maximum metadata size across all documents and adjusts
+    the effective chunk size accordingly to ensure that metadata fits within each chunk.
+
+    Metadata keys with `None` values are excluded from the embedded metadata in the text.
     """
     # TODO: find a better way to find the biggest metadata
     max_size_of_metadata = 0

--- a/dockers/llm.vdb.service/common.py
+++ b/dockers/llm.vdb.service/common.py
@@ -24,13 +24,13 @@ def load_jsonl_files_from_directory(directory):
     return data
 
 
-def get_documents_with_metadata(data):
+def get_documents(data):
     texts = [doc["text"] for doc in data]
     metadatas = [doc["metadata"] for doc in data]
     return texts, metadatas
 
 
-def chunk_documents_with_metadata(data, chunk_size, chunk_overlap):
+def chunk_documents(data, chunk_size, chunk_overlap):
     """
     Chunks documents while maintaining alignment between text chunks and metadata
     """
@@ -60,7 +60,7 @@ def chunk_documents_with_metadata(data, chunk_size, chunk_overlap):
     return all_chunks, all_metadatas
 
 
-def chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size, chunk_overlap):
+def chunk_documents_with_added_metadata(data, chunk_size, chunk_overlap):
     """
     Splits documents into smaller text chunks while preserving alignment with metadata.
     Additionally, each chunk is enriched by embedding its corresponding metadata into the text.
@@ -122,14 +122,14 @@ def create_vectordb_from_data(
     chunk_overlap,
 ):
     # no chunking
-    # texts, metadatas = get_documents_with_metadata(data)
+    # texts, metadatas = get_documents(data)
 
     # with chunking texts
-    # texts, metadatas = chunk_documents_with_metadata(data, chunk_size, chunk_overlap)
+    # texts, metadatas = chunk_documents(data, chunk_size, chunk_overlap)
 
     # with adding metadata to text
     print("Start chunking documents")
-    texts, metadatas = chunk_documents_with_metadata_add_metadata_to_text(data, chunk_size, chunk_overlap)
+    texts, metadatas = chunk_documents_with_added_metadata(data, chunk_size, chunk_overlap)
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
     print("Convert to FAISS vectorstore")

--- a/scripts/process_zendesk_tickets.py
+++ b/scripts/process_zendesk_tickets.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 from configparser import ConfigParser
 from typing import Any, Dict, List, Union
@@ -9,7 +10,9 @@ def clean_text(text: Any) -> str:
     """Clean and standardize text content."""
     if text is None or text == "":
         return ""
-    return str(text).strip().replace("\n", " ").replace("\r", " ")
+    result = str(text).strip().replace("\n", " ").replace("\r", " ")
+    result = re.sub(r'-{3,}', '-', result)
+    return re.sub(r' {2,}', ' ', result)
 
 def get_nested_value(data: Dict[str, Any], field_path: str) -> Any:
     """Extract value from nested dictionary using dot notation.
@@ -155,13 +158,6 @@ def process_item(
         if values:
             result_text.append(f"{target_field.lower()}: {' '.join(values)}")
     
-    # Process list fields
-    for field in config["list_fields"]:
-        if field in data:
-            values = parse_list(data[field])
-            if values:
-                result_text.append(f"{field.lower()}: {', '.join(values)}")
-    
     # Build metadata
     metadata = {}
     for field, column in config["metadata_fields"].items():
@@ -175,6 +171,13 @@ def process_item(
         else:
             value = data.get(column, "")
         metadata[field.lower()] = clean_text(value)
+
+    # Process list fields
+    for field in config["list_fields"]:
+        if field in data:
+            values = parse_list(data[field])
+            if values:
+                metadata[field.lower()] = ", ".join(values)
     
     # Add source URL
     metadata_unique_id = config["metadata_unique_id"]

--- a/scripts/process_zendesk_tickets.py
+++ b/scripts/process_zendesk_tickets.py
@@ -12,7 +12,7 @@ def clean_text(text: Any) -> str:
         return ""
     result = str(text).strip().replace("\n", " ").replace("\r", " ")
     result = re.sub(r'-{3,}', '-', result)
-    return re.sub(r' {2,}', ' ', result)
+    return re.sub(r'\s+', ' ', result)
 
 def get_nested_value(data: Dict[str, Any], field_path: str) -> Any:
     """Extract value from nested dictionary using dot notation.

--- a/scripts/zendesk_config.ini
+++ b/scripts/zendesk_config.ini
@@ -25,9 +25,10 @@ Updated_at = updated_at
 [MetadataFields]
 ticket = id
 title = subject
-type = type
 status = status
+type = type
 priority = priority
+collaborator = collaborator.name
 submitter = submitter.name
 assignee = assignee.name
 organization = organization.name

--- a/scripts/zendesk_config.ini
+++ b/scripts/zendesk_config.ini
@@ -16,6 +16,7 @@ status = status
 type = type
 priority = priority
 collaborator = collaborator.name
+requester = requester.name
 submitter = submitter.name
 assignee = assignee.name
 organization = organization.name

--- a/scripts/zendesk_config.ini
+++ b/scripts/zendesk_config.ini
@@ -7,20 +7,7 @@ comments_body = comments.body
 fields = tags
 
 [CompositeTextFields]
-Ticket = id
-Title = subject
 Description = description
-Status = status
-Type = type
-Priority = priority
-Collaborator = collaborator.name
-Requester = requester.name
-Submitter = submitter.name
-Assignee = assignee.name
-Organization = organization.name
-Group = group.name
-Created_at = created_at
-Updated_at = updated_at
 
 [MetadataFields]
 ticket = id


### PR DESCRIPTION
- Update zendesk tickets processing script to put only description and comments in text field and all the other fields to metadata
- Add new chunking method which enriches each chunk with the data from metadata. 
- The method determines the maximum metadata size across all documents and adjusts the effective chunk size accordingly to ensure that metadata fits within each chunk.
- Added some extra cleaning of data in the data preparation script.