### PR TITLE
Add a question router to choose between SQL and vector (hybrid) search

### DIFF
--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -178,10 +178,16 @@ def get_answer_with_settings(question, retriever, client, model_id, max_tokens, 
 
     answer = postprocess_hallucinations(generated_answer)
 
+    sources = [r.metadata["source"] for r in docs]
+    unique_sources = list(set(sources))
+
+    tickets = [r.metadata["ticket"] for r in docs]
+    unique_tickets = list(set(tickets))
+
     answerToUI = {
         "answer": answer,
-        "relevant_tickets": [r.metadata["ticket"] for r in docs],
-        "sources": [r.metadata["source"] for r in docs],
+        "relevant_tickets": unique_tickets,
+        "sources": unique_sources,
         "context": context,  # TODO: if this is big consider logger context here and sending some reference id to UI
     }
     return answerToUI

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -207,9 +207,9 @@ def get_sql_answer(question, model_id, max_tokens, model_temperature, llm_server
         )        
 
         logger.info("Loading the pre-created SQL DB")
-        #engine = create_engine("sqlite:////app/db/zendesk.db")
+        engine = create_engine("sqlite:////app/db/zendesk.db")
         # uncomment for local run
-        engine = create_engine("sqlite:////tmp/db/zendesk.db")
+        # engine = create_engine("sqlite:////tmp/db/zendesk.db")
 
         logger.info("Check that the SQL data can be accessed from the DB via querying")
         db = SQLDatabase(engine=engine)
@@ -506,15 +506,15 @@ def predict_question_type(question, model, tfidf, id_to_category):
 
 def load_models():
     # Load the saved model
-    #rf_model_path = "/app/db/random_forest_model.pkl"
+    rf_model_path = "/app/db/random_forest_model.pkl"
     #uncomment for local run
-    rf_model_path = "/tmp/db/random_forest_model.pkl"
+    #rf_model_path = "/tmp/db/random_forest_model.pkl"
     rf_model_loaded = joblib.load(rf_model_path)
 
     # Load the saved TF-IDF vectorizer
-    #tfidf_path = "/app/db/tfidf_vectorizer.pkl"
+    tfidf_path = "/app/db/tfidf_vectorizer.pkl"
     #uncomment for local run
-    tfidf_path = "/tmp/db/tfidf_vectorizer.pkl"
+    #tfidf_path = "/tmp/db/tfidf_vectorizer.pkl"
     tfidf_loaded = joblib.load(tfidf_path)
 
     logging.info("Model and vectorizer loaded successfully.")

--- a/dockers/llm.rag.service/serverragllm_csv_to_weaviate_local.py
+++ b/dockers/llm.rag.service/serverragllm_csv_to_weaviate_local.py
@@ -89,6 +89,7 @@ def setup(
         model_temperature=model_temperature,
         system_prompt=SYSTEM_PROMPT_DEFAULT,
         relevant_docs=relevant_docs,
+        llm_server_url=llm_server_url,
     )
 
     @app.get("/answer/{question}")
@@ -110,10 +111,9 @@ relevant_docs = int(os.getenv("RELEVANT_DOCS", RELEVANT_DOCS_DEFAULT))
 # llm_server_url = os.getenv("MODEL_LLM_SERVER_URL", "http://localhost:11434/v1")
 llm_server_url = os.getenv("MODEL_LLM_SERVER_URL", "http://localhost:9000/v1")
 # model_id = os.getenv("MODEL_ID", "llama2")
-model_id = os.getenv("MODEL_ID", "microsoft/Phi-3-mini-4k-instruct")
-# model_id = os.getenv("MODEL_ID", "microsoft/Phi-3-mini-128k-instruct")
-# model_id = os.getenv("MODEL_ID", "rubra-ai/Phi-3-mini-128k-instruct")
-# model_id = os.getenv("MODEL_ID", "phi3")
+
+# model_id = os.getenv("MODEL_ID", "microsoft/Phi-3-mini-4k-instruct")
+model_id = os.getenv("MODEL_ID", "rubra-ai/Phi-3-mini-128k-instruct")
 max_tokens = int(os.getenv("MAX_TOKENS", MAX_TOKENS_DEFAULT))
 model_temperature = float(os.getenv("MODEL_TEMPERATURE", MODEL_TEMPERATURE_DEFAULT))
 

--- a/dockers/llm.rag.service/serverragllm_zendesk_csv_sql_local.py
+++ b/dockers/llm.rag.service/serverragllm_zendesk_csv_sql_local.py
@@ -25,11 +25,8 @@ from openai import OpenAI
 
 from common import get_answer_with_settings
 from common import get_sql_answer
-from enum import Enum
-
-class SearchType(Enum):
-    SQL = 1
-    VECTOR = 2
+from common import question_router
+from common import SearchType
 
 def setup(
         file_path: str,
@@ -42,6 +39,7 @@ def setup(
     app = FastAPI()
 
     # TO DO: Add question classification block
+    # search_type = question_router(question) 
 
     # For now, hard-coding question type to aggregation
     search_type = SearchType.SQL
@@ -132,7 +130,7 @@ model_temperature = float(os.getenv("MODEL_TEMPERATURE", MODEL_TEMPERATURE_DEFAU
 app = setup(file_path, relevant_docs, llm_server_url, model_id, max_tokens, model_temperature)
 
 @click.command()
-@click.option("--host", default="127.0.0.1", help="Host for the FastAPI server (default: 127.0.0.1)")
+@click.option("--host", default="127.0.0.1", help="Host for the FastAPI     server (default: 127.0.0.1)")
 @click.option("--port", type=int, default=8000, help="Port for the FastAPI server (default: 8000)")
 def run(host, port):
     # Serve the app using Uvicorn

--- a/question_classification/predict/question_classification.py
+++ b/question_classification/predict/question_classification.py
@@ -1,0 +1,33 @@
+import os
+import joblib
+
+def predict_question_type(question, model, tfidf, id_to_category):
+    
+    # Transform the input question into TF-IDF feature representation
+    question_tfidf = tfidf.transform([question]).toarray()
+
+    # Predict the category ID
+    predicted_category_id = model.predict(question_tfidf)[0]
+
+    # Convert category ID back to label
+    predicted_category = id_to_category[predicted_category_id]
+
+    return predicted_category
+
+def load_models():
+    # Load the saved model
+    rf_model_loaded = joblib.load('./models/random_forest_model.pkl')
+
+    # Load the saved TF-IDF vectorizer
+    tfidf_loaded = joblib.load('./models/tfidf_vectorizer.pkl')
+
+    print("Model and vectorizer loaded successfully!")
+    return rf_model_loaded, tfidf_loaded
+
+sample_question = "How many tickets are there?"
+#sample_question = "What was the last upgrade issue?"
+rf_model_loaded, tfidf_loaded = load_models()
+id_to_category = {0: 'aggregation', 1: 'pointed'}
+predicted_category = predict_question_type(sample_question, rf_model_loaded, tfidf_loaded, id_to_category)
+
+print("Testing with a sample question: ", sample_question, "\nPredicted Question Type:", predicted_category)

--- a/question_classification/predict/requirements.txt
+++ b/question_classification/predict/requirements.txt
@@ -1,0 +1,1 @@
+scikit-learn

--- a/question_classification/train/question_classification_models.py
+++ b/question_classification/train/question_classification_models.py
@@ -1,0 +1,69 @@
+import os
+import joblib
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.ensemble import RandomForestClassifier
+
+
+def predict_question_type(question, model, tfidf, id_to_category):
+    # Transform the input question into TF-IDF feature representation
+    question_tfidf = tfidf.transform([question]).toarray()
+
+    # Predict the category ID
+    predicted_category_id = model.predict(question_tfidf)[0]
+
+    # Convert category ID back to label
+    predicted_category = id_to_category[predicted_category_id]
+
+    return predicted_category
+
+# Save the trained model
+def save_models(rf_model, tfidf):
+    joblib.dump(rf_model, 'random_forest_model.pkl')
+
+    # Save the TF-IDF vectorizer as well (since it's needed for transforming new data)
+    joblib.dump(tfidf, 'tfidf_vectorizer.pkl')
+
+    print("Model and vectorizer saved successfully!")
+
+# loading data, replace with questions specific to your dataset
+df = pd.read_csv('syntheticquestions.csv')
+
+# Create a new dataframe with two columns
+df1 = df[['question', 'question_type']].copy()
+df1.head(3).T
+df2=df1
+
+# map categories to numbers
+# Create a new column 'category_id' with encoded categories
+df2['category_id'] = df2['question_type'].factorize()[0]
+category_id_df = df2[['question_type', 'category_id']].drop_duplicates()
+
+# Dictionaries for future use
+category_to_id = dict(category_id_df.values)
+id_to_category = dict(category_id_df[['category_id', 'question_type']].values)
+
+print("ID to category Dict:", id_to_category)
+
+# New dataframe
+df2.head()
+
+# find features and labels
+tfidf = TfidfVectorizer(sublinear_tf=True, min_df=1,
+                        ngram_range=(1, 2),
+                        stop_words='english')
+
+# transform each question into a vector
+features = tfidf.fit_transform(df2.question).toarray()
+labels = df2.category_id
+print("Each of the %d questions is represented by %d features (TF-IDF score of unigrams and bigrams)" %(features.shape))
+
+print("Model training starts...")
+rf_model = RandomForestClassifier(n_estimators=100, max_depth=5, random_state=0)
+rf_model.fit(features, labels)
+
+sample_question = "What was the last upgrade issue?"
+predicted_category = predict_question_type(sample_question, rf_model, tfidf, id_to_category)
+print("Testing with a sample question: ", sample_question, "\nPredicted Question Type:", predicted_category)
+
+save_models(rf_model, tfidf)

--- a/question_classification/train/requirements.txt
+++ b/question_classification/train/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+scikit-learn


### PR DESCRIPTION
This PR includes a question router. This router determines whether an incoming question will be handled by the SQL search or the RAG vector search. RAG vector search is parametrized to enable hybrid search i.e. a combination of vector search and text search. 

The question classification module uses a random forest classifier trained against synthetic questions (not included in this repo). The two classes are

1. "aggregation" questions
2. "pointed" questions.

SQL search code path is chosen for:
A. all aggregation questions, as well as,
B. questions that symbols or numerals in the questions. 

B is included in the SQL search type, because vector search does not handle alphanumeric words in a question such as: IP addresses, ticket numbers, etc.


