### PR TITLE
Fix to retain RAG only Question-Answer Chatbot

### DIFF
--- a/demo/llm.rag.service/rag-serveragllmpluslb.yaml
+++ b/demo/llm.rag.service/rag-serveragllmpluslb.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: serveragllm-deployment
+  labels:
+    app: modelragllmserve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      model: serveragllm
+  template:
+    metadata:
+      labels:
+        model: serveragllm
+        elotl-luna: "true"
+      annotations:
+        node.elotl.co/instance-type-regexp: "^(t3.xlarge|n2-standard-4)$"
+    spec:
+      containers:
+        - name: serveragllm
+          image: elotl/serveragllm:v1.3.12
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              cpu: "1.5"
+              memory: "1G"
+          env:
+          - name: MODEL_LLM_SERVER_URL
+            value: ${MODEL_LLM_SERVER_URL}
+          - name: AWS_ACCESS_KEY_ID
+            value: ${AWS_ACCESS_KEY_ID}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${AWS_SECRET_ACCESS_KEY}
+          - name: VECTOR_DB_S3_BUCKET
+            value: ${VECTOR_DB_S3_BUCKET}
+          - name: VECTOR_DB_S3_FILE
+            value: ${VECTOR_DB_S3_FILE}
+          - name: SYSTEM_PROMPT
+            value: ${SYSTEM_PROMPT}
+          - name: MODEL_ID
+            value: ${MODEL_ID}
+          - name: MAX_TOKENS
+            value: ${MAX_TOKENS}
+          - name: MODEL_TEMPERATURE
+            value: ${MODEL_TEMPERATURE}
+          - name: RELEVANT_DOCS
+            value: ${RELEVANT_DOCS}
+          - name: IS_JSON_MODE
+            value: "${IS_JSON_MODE}"
+          volumeMounts:
+          - name: log-storage
+            mountPath: /app/logs
+      volumes:
+      - name: log-storage
+        persistentVolumeClaim:
+          claimName: rag-llm-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: serveragllm-service
+  labels:
+    app: modelragllmserve
+spec:
+  type: ClusterIP
+  selector:
+    model: serveragllm
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/docs/install.md
+++ b/docs/install.md
@@ -362,10 +362,10 @@ You can use this AWS cli command to verify that it was created correctly:
 
 ## Setup RAG + LLM service
 
-We will now create a Kubernetes Deployment and a Service that will take in the user’s question, interact with the Vector Store to find relevant documents and then query our hosted LLM service to provide an answer. You can download the manifest chat-serveragllm.yaml from here: [chat-serveragllmpluslb.yaml](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.rag.service/chat-serveragllmpluslb.yaml)
+We will now create a Kubernetes Deployment and a Service that will take in the user’s question, interact with the Vector Store to find relevant documents and then query our hosted LLM service to provide an answer. You can download the manifest rag-chat-serveragllm.yaml from here: [rag-chat-serveragllmpluslb.yaml](https://github.com/elotl/GenAI-infra-stack/blob/main/demo/llm.rag.service/rag-chat-serveragllmpluslb.yaml)
 
 ```sh
-envsubst < chat-serveragllmpluslb.yaml | kubectl apply -f -
+envsubst < rag-chat-serveragllmpluslb.yaml | kubectl apply -f -
 ```
 
 Please wait for the deployment and Kubernetes LoadBalancer service to become ready and to also obtain an external IP. This can take a few minutes. The command outputs below specifically show the deployment, pod and services associated with the RAQ LLM service.


### PR DESCRIPTION
This will ensure that RAG only version of the Question Answer Chatbot + FAISS vector store will be top of head and available.
