### PR TITLE
Speed up query execution

### DIFF
--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -237,11 +237,11 @@ def get_sql_answer(question, model_id, max_tokens, model_temperature, llm_server
         return errorToUI
 
     # send SQL query and response to LLM and get a natural language answer
-    # TODO avoid calling text to SQL conversion twice
+    query = write_query({"question": question}, query_prompt_template, llm, db)
     state: State = {
         "question": question,
-        "query": write_query({"question": question}, query_prompt_template, llm, db),
-        "result": execute_query(write_query({"question": question}, query_prompt_template, llm, db), db),
+        "query": query,
+        "result": execute_query(query, db),
     }
     generated_answer = convert_sql_result_to_nl(state, model_id, llm)
     answer = postprocess_hallucinations(generated_answer['answer'])

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -51,7 +51,6 @@ class State(TypedDict):
     question: str
     query: str
     result: str
-    answer: str
 
 
 class SearchType(Enum):

--- a/dockers/llm.rag.service/common.py
+++ b/dockers/llm.rag.service/common.py
@@ -1,11 +1,10 @@
 import logging
 import logging.config
 import re
-import os
-import joblib
 from enum import Enum
 from typing import Any, Dict, List
 
+import joblib
 from langchain_community.chat_models import ChatOpenAI
 from langchain_community.tools.sql_database.tool import QuerySQLDataBaseTool
 from langchain_community.utilities import SQLDatabase
@@ -14,7 +13,6 @@ from openai import BadRequestError
 from sqlalchemy import create_engine
 from transformers import AutoTokenizer
 from typing_extensions import Annotated, TypedDict
-
 
 LOGGING_CONFIG = {
     'version': 1,

--- a/dockers/llm.rag.service/common_test.py
+++ b/dockers/llm.rag.service/common_test.py
@@ -1,6 +1,5 @@
 from common import trim_answer
 
-
 test_string = """
 A recent SSH issue customers had was related to SSH access being flagged as a problem in their old environment because it was under a reseller account. This issue was identified as a "Won\'t Fix" and the Linux Support Engineer informed the customer that they would need to let their security vendor know about these details so they can be excluded from the report as "False Positives."<|im_end|> 
 

--- a/dockers/llm.rag.service/proxy_app.py
+++ b/dockers/llm.rag.service/proxy_app.py
@@ -1,4 +1,5 @@
 import os
+
 import uvicorn
 
 

--- a/dockers/llm.rag.service/serveragllm.py
+++ b/dockers/llm.rag.service/serveragllm.py
@@ -1,19 +1,17 @@
+import logging
 import os
 import pickle
 import sys
-from typing import Any, Dict, List, Union
 from enum import Enum
+from logging.handlers import TimedRotatingFileHandler
+from typing import Any, Dict, List, Union
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from fastapi import FastAPI
 from openai import OpenAI
 
-import logging
-from logging.handlers import TimedRotatingFileHandler
-
-from common import get_answer_with_settings
-from common import get_sql_answer
+from common import get_answer_with_settings, get_sql_answer
 
 ########
 # Setup model name and query template parameters

--- a/dockers/llm.rag.service/serverragllm_csv_to_weaviate_local.py
+++ b/dockers/llm.rag.service/serverragllm_csv_to_weaviate_local.py
@@ -14,17 +14,15 @@
 
 import os
 import sys
-import uvicorn
-
 from functools import partial
 from typing import Union
 
 import click
+import uvicorn
 from fastapi import FastAPI
 from openai import OpenAI
 
 from common import get_answer_with_settings_with_weaviate_filter
-
 
 SYSTEM_PROMPT_DEFAULT = """You are a specialized support ticket assistant. Format your responses following these rules:
                 1. Answer the provided question only using the provided context.
@@ -52,8 +50,8 @@ def setup(
 
     # TODO: move to imports
     import weaviate
-    from langchain_weaviate.vectorstores import WeaviateVectorStore
     from langchain_huggingface import HuggingFaceEmbeddings
+    from langchain_weaviate.vectorstores import WeaviateVectorStore
 
     embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
 

--- a/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
+++ b/dockers/llm.rag.service/serverragllm_jira_cvs_local.py
@@ -13,12 +13,11 @@
 import os
 import pickle
 import sys
-import uvicorn
-
 from functools import partial
 from typing import Union
 
 import click
+import uvicorn
 from fastapi import FastAPI
 from openai import OpenAI
 

--- a/dockers/llm.rag.service/serverragllm_zendesk_csv_sql_local.py
+++ b/dockers/llm.rag.service/serverragllm_zendesk_csv_sql_local.py
@@ -10,23 +10,21 @@
 # ]
 # ///
 
+import logging
 import os
 import pickle
 import sys
-import logging
-import uvicorn
-
 from functools import partial
 from typing import Union
 
 import click
+import uvicorn
 from fastapi import FastAPI
 from openai import OpenAI
 
-from common import get_answer_with_settings
-from common import get_sql_answer
-from common import question_router
-from common import SearchType
+from common import (SearchType, get_answer_with_settings, get_sql_answer,
+                    question_router)
+
 
 def setup(
         file_path: str,


### PR DESCRIPTION
We called write_query with the same parameters twice. We can call it once and use the output twice. This should save us approx. 25% of execution time.

Measured before this change:
```
----> Write query execution time: 11.730087 seconds
----> Execute query execution time: 11.444552 seconds
----> Get answer execution time: 20.009238 seconds

----> Execution time: 43.491239 seconds
``` 

measured after this change:
```
----> Write query execution time: 6.158734 seconds
----> Execute query execution time: 0.000908 seconds
----> Get answer execution time: 11.245217 seconds

----> Execution time: 17.741704 seconds
```

Additionally some formatting and import sorting was applied.