### PR TITLE
Convert Chat UI to a Text Summarizer UI

### DIFF
--- a/demo/llm.summarizerui.service/auth-proxy.yml
+++ b/demo/llm.summarizerui.service/auth-proxy.yml
@@ -1,0 +1,93 @@
+# nginx-auth-proxy-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-auth-proxy-config
+data:
+  nginx.conf: |
+    events {
+      worker_connections 1024;
+    }
+    http {
+      server {
+        listen 80;
+        
+        location / {
+          auth_basic "Restricted Access";
+          auth_basic_user_file /etc/nginx/auth/.htpasswd;
+          
+          proxy_pass http://simple-chat-service.default.svc.cluster.local:7860;  # Points to our simple chat service
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+      }
+    }
+
+---
+# auth-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-proxy-credentials
+type: Opaque
+data:
+  # Generated using: htpasswd -c .htpasswd username
+  # Then base64 encode the file content
+  # htpasswd -c .htpasswd your_chosen_username
+  # cat .htpasswd | base64
+  # myuser:elotl
+
+  .htpasswd: ZWxvdGw6JGFwcjEkNlU4RllaOHIkMFh4Mm5MWW5pRGQuenNJYzhxb2t2MAo=
+
+---
+# auth-proxy-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-proxy
+spec:
+  replicas: 2  # For high availability
+  selector:
+    matchLabels:
+      app: auth-proxy
+  template:
+    metadata:
+      labels:
+        app: auth-proxy
+    spec:
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-auth-proxy-config
+      - name: auth-volume
+        secret:
+          secretName: auth-proxy-credentials
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: auth-volume
+          mountPath: /etc/nginx/auth
+          readOnly: true
+
+---
+# auth-proxy-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-proxy-service
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: auth-proxy

--- a/demo/llm.summarizerui.service/pv-and-pvc.yaml
+++ b/demo/llm.summarizerui.service/pv-and-pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: simple-chat-pv
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /mnt/data/simple-chat-logs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: simple-chat-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/demo/llm.summarizerui.service/simple-chat.yaml
+++ b/demo/llm.summarizerui.service/simple-chat.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-chat
+  labels:
+    app: simple-chat
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simple-chat
+  template:
+    metadata:
+      labels:
+        app: simple-chat
+        elotl-luna: "true"
+      annotations:
+        node.elotl.co/instance-type-regexp: "^(t3.xlarge|n2-standard-4)$"
+    spec:
+      containers:
+      - name: chat
+        image: elotl/summarizerui:0.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 7860
+        env:
+        - name: INFERENCE_QUERY_URL
+          value: "http://localhost:8000"
+        - name: USE_CHATBOT_HISTORY
+          value: "True"
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        volumeMounts:
+        - name: log-storage
+          mountPath: /app/logs
+      volumes:
+      - name: log-storage
+        persistentVolumeClaim:
+          claimName: simple-chat-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple-chat-service
+spec:
+  selector:
+    app: simple-chat
+  ports:
+    - protocol: TCP
+      port: 7860
+      targetPort: 7860
+  type: ClusterIP

--- a/demo/llm.summarizerui.service/simple-chat.yaml
+++ b/demo/llm.summarizerui.service/simple-chat.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/summarizerui:0.3
+        image: elotl/summarizerui:0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7860

--- a/demo/llm.summarizerui.service/simple-chat.yaml
+++ b/demo/llm.summarizerui.service/simple-chat.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/summarizerui:0.2
+        image: elotl/summarizerui:0.3
         imagePullPolicy: Always
         ports:
         - containerPort: 7860

--- a/demo/llm.summarizerui.service/simple-chat.yaml
+++ b/demo/llm.summarizerui.service/simple-chat.yaml
@@ -19,13 +19,13 @@ spec:
     spec:
       containers:
       - name: chat
-        image: elotl/summarizerui:0.1
+        image: elotl/summarizerui:0.2
         imagePullPolicy: Always
         ports:
         - containerPort: 7860
         env:
         - name: INFERENCE_QUERY_URL
-          value: "http://localhost:8000"
+          value: "http://text-summarizer-serve-svc.default.svc.cluster.local:8000"
         - name: USE_CHATBOT_HISTORY
           value: "True"
         resources:

--- a/dockers/llm.summarizerui.service/Dockerfile
+++ b/dockers/llm.summarizerui.service/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base-container
+
+# Automatically set by buildx
+ARG TARGETPLATFORM
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only essential dependencies, clean up after install to reduce image size
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3-pip && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /simple_chat
+
+# Copy application code and requirements.txt for dependency installation
+COPY simple_chat.py .
+COPY requirements.txt .
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/pip \
+  pip3 install --upgrade pip && \
+  pip3 install --no-cache-dir -r requirements.txt
+
+# Expose the Gradio port
+EXPOSE 7860
+
+# Start the application
+CMD ["python", "simple_chat.py"]

--- a/dockers/llm.summarizerui.service/README.md
+++ b/dockers/llm.summarizerui.service/README.md
@@ -1,0 +1,61 @@
+# Using this Text Summarizer UI
+
+
+## Deploy the sample Ray Service
+
+
+Text Summarizer Ray Service: https://docs.ray.io/en/latest/cluster/kubernetes/examples/text-summarizer-rayservice.html
+
+
+Steps to install the Ray Service:
+
+
+## Install Ray Operator
+
+Install helm chart
+
+```bash
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+helm install kuberay-operator kuberay/kuberay-operator --version 1.3.0
+```
+
+Check that the kuberay operator was deployed:
+
+```bash
+% helm ls
+NAME            	NAMESPACE	REVISION	UPDATED                            	STATUS  	CHART                 	APP VERSION
+kuberay-operator	default  	1       	2025-05-30 10:34:42.20226 -0700 PDT	deployed	kuberay-operator-1.3.0	           
+```
+
+```bash
+% kubectl get pods
+NAME                                READY   STATUS    RESTARTS   AGE
+kuberay-operator-66d848f5cd-6tc9z   1/1     Running   0          42s
+```
+
+
+## Install text summarizer Ray Service
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.text-summarizer.yaml
+```
+
+
+Check that the summarizer service and pods are created:
+
+```bash
+% kubectl get svc
+NAME                                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                         AGE
+kuberay-operator                            ClusterIP   10.100.10.124   <none>        8080/TCP                                        2m32s
+kubernetes                                  ClusterIP   10.100.0.1      <none>        443/TCP                                         50d
+text-summarizer-raycluster-8xmdp-head-svc   ClusterIP   None            <none>        10001/TCP,8265/TCP,6379/TCP,8080/TCP,8000/TCP   74s
+selvik@Selvis-MacBook-Pro llm.summarizerui.service % kubectl get pods
+NAME                                                      READY   STATUS              RESTARTS   AGE
+kuberay-operator-66d848f5cd-6tc9z                         1/1     Running             0          2m44s
+text-summarizer-raycluster-8xmdp-gpu-group-worker-qmf99   0/1     Pending             0          86s
+text-summarizer-raycluster-8xmdp-head-t2vfd               0/1     ContainerCreating   0          86s
+```
+
+
+

--- a/dockers/llm.summarizerui.service/README.md
+++ b/dockers/llm.summarizerui.service/README.md
@@ -38,7 +38,7 @@ kuberay-operator-66d848f5cd-6tc9z   1/1     Running   0          42s
 ## Install text summarizer Ray Service
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.text-summarizer.yaml
+envsubst < supernova-rayservice.yaml | kubectl apply  -f -
 ```
 
 
@@ -57,5 +57,9 @@ text-summarizer-raycluster-8xmdp-gpu-group-worker-qmf99   0/1     Pending       
 text-summarizer-raycluster-8xmdp-head-t2vfd               0/1     ContainerCreating   0          86s
 ```
 
+
+Edit deployment's LLM URL to:
+
+http://text-summarizer-serve-svc.default.svc.cluster.local:8000
 
 

--- a/dockers/llm.summarizerui.service/requirements.txt
+++ b/dockers/llm.summarizerui.service/requirements.txt
@@ -1,0 +1,2 @@
+gradio
+requests

--- a/dockers/llm.summarizerui.service/simple_chat.py
+++ b/dockers/llm.summarizerui.service/simple_chat.py
@@ -31,7 +31,7 @@ if INFERENCE_QUERY_URL is None:
     )
     sys.exit(1)
 
-logging.info(f"RAG query endpoint, INFERENCE_QUERY_URL: {INFERENCE_QUERY_URL}")
+logging.info(f"Inference query endpoint, INFERENCE_QUERY_URL: {INFERENCE_QUERY_URL}")
 
 USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "True") == "True"
 
@@ -73,8 +73,12 @@ def generate_source_links(sources):
 def get_api_response(user_message):
     try:
         text = urllib.parse.quote(f"{user_message}")
+
+        logging.info(f"Received text for summarization: {text}")
+        
         response = requests.get(f"{INFERENCE_QUERY_URL}/summarize/text={text}")
         if response.status_code == 200:
+            logging.info(f"resonse is: {response}\n")
             result = response.json()
 
 	    #json_key_in_response="answer"
@@ -149,7 +153,7 @@ with gr.Blocks() as app:
             )
             submit_rating_btn = gr.Button("Submit Rating", visible=False)
 
-            msg = gr.Textbox(placeholder="Enter text to be summarized here...", label="InputText")
+            msg = gr.Textbox(placeholder="Enter text to be summarized here...", label="Input Text")
             send_button = gr.Button("Send")
     # Hidden variables to hold user_message and bot_response for rating submission
     user_message = gr.State()

--- a/dockers/llm.summarizerui.service/simple_chat.py
+++ b/dockers/llm.summarizerui.service/simple_chat.py
@@ -216,5 +216,21 @@ with gr.Blocks() as app:
         inputs=[rating_slider, user_message, bot_response],
         outputs=[rating_slider, submit_rating_btn],
     )
+ 
+    # Apply large font styling
+    app.css("""
+        * {
+            font-size: 20px !important;
+        }
+        textarea, input {
+            font-size: 20px !important;
+        }
+        .prose, .gr-chatbot, .gr-button, .gr-textbox, .gr-slider {
+            font-size: 20px !important;
+        }
+        label {
+            font-size: 20px !important;
+        }
+    """)
 
 app.launch(server_name="0.0.0.0")

--- a/dockers/llm.summarizerui.service/simple_chat.py
+++ b/dockers/llm.summarizerui.service/simple_chat.py
@@ -1,0 +1,216 @@
+import logging
+import os
+import sys
+import urllib
+from logging.handlers import TimedRotatingFileHandler
+
+import gradio as gr
+import requests
+
+# When running locally: export CHATUI_LOGS_PATH=logs/chatui.log
+log_file_path = os.getenv("CHATUI_LOGS_PATH") or "/app/logs/chatui.log"
+os.makedirs(
+    os.path.dirname(log_file_path), exist_ok=True
+)  # Ensure log directory exists
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        # Log to file, rotate every 1H and store files from last 24 hrs * 7 days files == 168H data
+        TimedRotatingFileHandler(log_file_path, when="h", interval=1, backupCount=168),
+        logging.StreamHandler(),  # Also log to console
+    ],
+)
+
+# Environment variable setup
+INFERENCE_QUERY_URL = os.getenv("INFERENCE_QUERY_URL")
+
+if INFERENCE_QUERY_URL is None:
+    logging.error(
+        "Please set the environment variable, INFERENCE_QUERY_URL (to the IP of the LLM INFERENCE endpoint)"
+    )
+    sys.exit(1)
+
+logging.info(f"RAG query endpoint, INFERENCE_QUERY_URL: {INFERENCE_QUERY_URL}")
+
+USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "True") == "True"
+
+logging.info(f"Use history {USE_CHATBOT_HISTORY}")
+
+
+def clean_answer(text: str, chatml_end_token: str) -> str:
+    """
+    Remove all content after and including the specified token from the text.
+    Args:
+        text (str): The input text to clean
+        chatml_end_token (str): The token after which all content should be removed
+    Returns:
+        str: Cleaned text with all content after and including the token removed
+    """
+    if not text:  # Handle empty text
+        return ""
+
+    if not chatml_end_token:  # Handle empty end tokens
+        return text
+
+    # Split text at the token and take only the content before it
+    if chatml_end_token in text:
+        text = text.split(chatml_end_token, 1)[0]
+        logging.info(f"Cleaned text before chatml_end_token: {text}")
+
+    return text.strip()
+
+
+# Function to generate clickable links for JIRA tickets
+def generate_source_links(sources):
+    links = []
+    for source in sources:
+        links.append(f'<a href="{source}" target="_blank">{source}</a>')
+    return links
+
+
+# Function to fetch the response from the RAG+LLM API
+def get_api_response(user_message):
+    try:
+        text = urllib.parse.quote(f"{user_message}")
+        response = requests.get(f"{INFERENCE_QUERY_URL}/summarize/text={text}")
+        if response.status_code == 200:
+            result = response.json()
+
+	    #json_key_in_response="answer"
+            #if json_key_in_response not in result.keys():
+            #    return "Could not fetch response."
+
+            #result = result[json_key_in_response]
+
+ 	    # we can skip cleanup of answer for text summarizer.
+            #answer = clean_answer(
+            #    result.get(json_key_in_response, "Could not fetch response."), "<|im_end|>"
+            #)
+
+            # sources = result.get("sources", [])
+            # links = generate_source_links(sources)
+            # clickable_links = "<br>".join(links)
+            #context = result.get("context", "")
+            logging.info(f"Input Text: {text}\nSummary: {result}\n")
+
+            #return f"{answer}<br><br>Relevant Tickets:<br>{clickable_links}"
+            return f"{result}"
+        else:
+            return "API Error: Unable to fetch response."
+    except requests.RequestException:
+        return "API Error: Failed to connect to the backend service."
+
+
+# Chatbot response functions
+def chatbot_response_no_hist(_chatbot, user_message):
+    response_text = get_api_response(user_message)
+    return (
+        [[user_message, response_text]],
+        "",
+        gr.update(value=1, visible=True),
+        gr.update(visible=True),
+        user_message,
+        response_text,
+    )
+
+
+def chatbot_response(history, user_message):
+    response_text = get_api_response(user_message)
+    history.append((user_message, response_text))
+    return (
+        history,
+        "",
+        gr.update(value=1, visible=True),
+        gr.update(visible=True),
+        user_message,
+        response_text,
+    )
+
+
+def submit_rating(rating, user_message, bot_response):
+    logging.info(
+        f"User rating: {rating}\nQuestion: {user_message}\nAnswer: {bot_response}"
+    )
+    # Hide the rating slider and submit button after submission
+    return gr.update(visible=False), gr.update(visible=False)
+
+
+# In the Gradio UI setup section, change:
+with gr.Blocks() as app:
+    with gr.Row():
+        with gr.Column(scale=4):
+            # Change from chatbot = gr.Chatbot() to:
+            chatbot = gr.Chatbot(label="Text Summarizer", height=600)
+
+            # Rating slider and submit button initially hidden
+            rating_slider = gr.Slider(
+                label="Rate the response", minimum=1, maximum=5, step=1, visible=False
+            )
+            submit_rating_btn = gr.Button("Submit Rating", visible=False)
+
+            msg = gr.Textbox(placeholder="Enter text to be summarized here...", label="InputText")
+            send_button = gr.Button("Send")
+    # Hidden variables to hold user_message and bot_response for rating submission
+    user_message = gr.State()
+    bot_response = gr.State()
+
+    if USE_CHATBOT_HISTORY:
+        msg.submit(
+            chatbot_response,
+            inputs=[chatbot, msg],
+            outputs=[
+                chatbot,
+                msg,
+                rating_slider,
+                submit_rating_btn,
+                user_message,
+                bot_response,
+            ],
+        )
+        send_button.click(
+            chatbot_response,
+            inputs=[chatbot, msg],
+            outputs=[
+                chatbot,
+                msg,
+                rating_slider,
+                submit_rating_btn,
+                user_message,
+                bot_response,
+            ],
+        )
+    else:
+        msg.submit(
+            chatbot_response_no_hist,
+            inputs=[chatbot, msg],
+            outputs=[
+                chatbot,
+                msg,
+                rating_slider,
+                submit_rating_btn,
+                user_message,
+                bot_response,
+            ],
+        )
+        send_button.click(
+            chatbot_response_no_hist,
+            inputs=[chatbot, msg],
+            outputs=[
+                chatbot,
+                msg,
+                rating_slider,
+                submit_rating_btn,
+                user_message,
+                bot_response,
+            ],
+        )
+
+    # Handle rating submission with the button
+    submit_rating_btn.click(
+        submit_rating,
+        inputs=[rating_slider, user_message, bot_response],
+        outputs=[rating_slider, submit_rating_btn],
+    )
+
+app.launch(server_name="0.0.0.0")

--- a/dockers/llm.summarizerui.service/simple_chat.py
+++ b/dockers/llm.summarizerui.service/simple_chat.py
@@ -37,30 +37,6 @@ USE_CHATBOT_HISTORY = os.getenv("USE_CHATBOT_HISTORY", "True") == "True"
 
 logging.info(f"Use history {USE_CHATBOT_HISTORY}")
 
-
-def clean_answer(text: str, chatml_end_token: str) -> str:
-    """
-    Remove all content after and including the specified token from the text.
-    Args:
-        text (str): The input text to clean
-        chatml_end_token (str): The token after which all content should be removed
-    Returns:
-        str: Cleaned text with all content after and including the token removed
-    """
-    if not text:  # Handle empty text
-        return ""
-
-    if not chatml_end_token:  # Handle empty end tokens
-        return text
-
-    # Split text at the token and take only the content before it
-    if chatml_end_token in text:
-        text = text.split(chatml_end_token, 1)[0]
-        logging.info(f"Cleaned text before chatml_end_token: {text}")
-
-    return text.strip()
-
-
 # Function to generate clickable links for JIRA tickets
 def generate_source_links(sources):
     links = []
@@ -80,31 +56,13 @@ def get_api_response(user_message):
         if response.status_code == 200:
             logging.info(f"resonse is: {response}\n")
             result = response.json()
-
-	    #json_key_in_response="answer"
-            #if json_key_in_response not in result.keys():
-            #    return "Could not fetch response."
-
-            #result = result[json_key_in_response]
-
- 	    # we can skip cleanup of answer for text summarizer.
-            #answer = clean_answer(
-            #    result.get(json_key_in_response, "Could not fetch response."), "<|im_end|>"
-            #)
-
-            # sources = result.get("sources", [])
-            # links = generate_source_links(sources)
-            # clickable_links = "<br>".join(links)
-            #context = result.get("context", "")
             logging.info(f"Input Text: {text}\nSummary: {result}\n")
 
-            #return f"{answer}<br><br>Relevant Tickets:<br>{clickable_links}"
             return f"{result}"
         else:
             return "API Error: Unable to fetch response."
     except requests.RequestException:
         return "API Error: Failed to connect to the backend service."
-
 
 # Chatbot response functions
 def chatbot_response_no_hist(_chatbot, user_message):
@@ -139,9 +97,24 @@ def submit_rating(rating, user_message, bot_response):
     # Hide the rating slider and submit button after submission
     return gr.update(visible=False), gr.update(visible=False)
 
+# Apply large font styling
+css = """
+    * {
+        font-size: 20px !important;
+    }
+    textarea, input {
+        font-size: 20px !important;
+    }
+    .prose, .gr-chatbot, .gr-button, .gr-textbox, .gr-slider {
+        font-size: 20px !important;
+    }
+    label {
+        font-size: 20px !important;
+    }
+"""
 
 # In the Gradio UI setup section, change:
-with gr.Blocks() as app:
+with gr.Blocks(css=css) as app:
     with gr.Row():
         with gr.Column(scale=4):
             # Change from chatbot = gr.Chatbot() to:
@@ -217,20 +190,5 @@ with gr.Blocks() as app:
         outputs=[rating_slider, submit_rating_btn],
     )
  
-    # Apply large font styling
-    app.css("""
-        * {
-            font-size: 20px !important;
-        }
-        textarea, input {
-            font-size: 20px !important;
-        }
-        .prose, .gr-chatbot, .gr-button, .gr-textbox, .gr-slider {
-            font-size: 20px !important;
-        }
-        label {
-            font-size: 20px !important;
-        }
-    """)
 
 app.launch(server_name="0.0.0.0")

--- a/dockers/llm.summarizerui.service/simple_chat.py
+++ b/dockers/llm.summarizerui.service/simple_chat.py
@@ -76,7 +76,7 @@ def get_api_response(user_message):
 
         logging.info(f"Received text for summarization: {text}")
         
-        response = requests.get(f"{INFERENCE_QUERY_URL}/summarize/text={text}")
+        response = requests.get(f"{INFERENCE_QUERY_URL}/summarize?text={text}")
         if response.status_code == 200:
             logging.info(f"resonse is: {response}\n")
             result = response.json()

--- a/dockers/llm.summarizerui.service/text_summarizer_req.py
+++ b/dockers/llm.summarizerui.service/text_summarizer_req.py
@@ -1,0 +1,12 @@
+import requests
+
+# Deploy service : serve run text_summarizer:deployment
+
+
+text = (
+    "Paris is the capital and most populous city of France, " +
+    "with an estimated population of 2,175,601 residents as of 2018, in an area of more than 105 square kilometres (41 square miles). " +
+    "The City of Paris is the centre and seat of government of the region and province of Île-de-France, or Paris Region, which has an estimated population of 12,174,880, or about 18 percent of the population of France as of 2017."
+)
+
+print(requests.get("http://localhost:8000/summarize", params={"text": text}).json())


### PR DESCRIPTION
The UI can be brought up with the following steps:

kubectl apply -f pv-and-pvc.yaml 
kubectl apply -f auth-proxy.yml
kubectl apply -f simple-chat.yaml

And UI's External IP can then be retrieved by:

```
% kubectl get svc
NAME                                        TYPE           CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)                                         AGE
auth-proxy-service                          LoadBalancer   10.100.160.247   abc.us-west-1.elb.amazonaws.com   80:32339/TCP                                    123m
```

If the text summarizer backend is running in a non-default workspace, then edit the service URL as shown below: 

```
kubectl edit deploy simple-chat  --context ${K8S_CLUSTER_CONTEXT_1}
```

```
    spec:
      containers:
      - env:
        - name: INFERENCE_QUERY_URL
          value: http://text-summarizer-serve-svc.default.svc.cluster.local:8000
        - name: USE_CHATBOT_HISTORY
          value: "True"
```



This URL can be opened on a browser and the text summarization functionality can be used:

![image](https://github.com/user-attachments/assets/26a9a59f-5d13-4b85-ad13-c8b5bf8be3ab)
